### PR TITLE
Add example of root.log failure

### DIFF
--- a/data/0005/README.md
+++ b/data/0005/README.md
@@ -1,0 +1,7 @@
+Example of a package whose failure is in root.log, not build.log
+
+Source: https://koji.fedoraproject.org/koji/taskinfo?taskID=130410241
+
+build.log: https://kojipkgs.fedoraproject.org//work/tasks/241/130410241/build.log
+root.log: https://kojipkgs.fedoraproject.org//work/tasks/241/130410241/root.log
+

--- a/data/0005/build.log
+++ b/data/0005/build.log
@@ -1,0 +1,167 @@
+Mock Version: 6.0
+Mock Version: 6.0
+Mock Version: 6.0
+ENTER ['do_with_status'](['bash', '--login', '-c', '/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/python-boto3.spec'], chrootPath='/var/lib/mock/eln-build-side-108102-58033177-6561774/root'env={'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8'}shell=Falselogger=<mockbuild.trace_decorator.getLog object at 0xffffa5fb9590>timeout=201600uid=1000gid=425user='mockbuild'unshare_net=TrueprintOutput=Falsenspawn_args=['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11'])
+Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11']
+Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '3f7879f71b68488aaf2b750b318e33a3', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '-a', '-u', 'mockbuild', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', 'bash', '--login', '-c', '/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/python-boto3.spec'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+Building target platforms: noarch
+Building for target noarch
+setting SOURCE_DATE_EPOCH=1742169600
+Wrote: /builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.src.rpm
+Child return code was: 0
+ENTER ['do_with_status'](['bash', '--login', '-c', '/usr/bin/rpmbuild -br --noclean --target noarch --nodeps /builddir/build/SPECS/python-boto3.spec'], chrootPath='/var/lib/mock/eln-build-side-108102-58033177-6561774/root'env={'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8'}shell=Falselogger=<mockbuild.trace_decorator.getLog object at 0xffffa5fb9590>timeout=201600uid=1000gid=425user='mockbuild'unshare_net=TrueraiseExc=FalseprintOutput=Falsenspawn_args=['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11'])
+Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11']
+Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '444bc997a3734506842a833517c037ff', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '-a', '-u', 'mockbuild', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', 'bash', '--login', '-c', '/usr/bin/rpmbuild -br --noclean --target noarch --nodeps /builddir/build/SPECS/python-boto3.spec'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+Building target platforms: noarch
+Building for target noarch
+setting SOURCE_DATE_EPOCH=1742169600
+Executing(%mkbuilddir): /bin/sh -e /var/tmp/rpm-tmp.6zkrGn
+Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.hS5Fet
++ umask 022
++ cd /builddir/build/BUILD/python-boto3-1.37.14-build
++ cd /builddir/build/BUILD/python-boto3-1.37.14-build
++ rm -rf boto3-1.37.14
++ /usr/lib/rpm/rpmuncompress -x /builddir/build/SOURCES/boto3-1.37.14.tar.gz
++ STATUS=0
++ '[' 0 -ne 0 ']'
++ cd boto3-1.37.14
++ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
++ RPM_EC=0
+++ jobs -p
++ exit 0
+Executing(%generate_buildrequires): /bin/sh -e /var/tmp/rpm-tmp.LaKv2X
++ umask 022
++ cd /builddir/build/BUILD/python-boto3-1.37.14-build
++ cd boto3-1.37.14
++ echo pyproject-rpm-macros
++ exit 0
+Wrote: /builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.buildreqs.nosrc.rpm
+Child return code was: 11
+Dynamic buildrequires detected
+Going to install missing buildrequires. See root.log for details.
+ENTER ['do_with_status'](['bash', '--login', '-c', '/usr/bin/rpmbuild -br --noprep --noclean --target noarch --nodeps /builddir/build/SPECS/python-boto3.spec'], chrootPath='/var/lib/mock/eln-build-side-108102-58033177-6561774/root'env={'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8'}shell=Falselogger=<mockbuild.trace_decorator.getLog object at 0xffffa5fb9590>timeout=201600uid=1000gid=425user='mockbuild'unshare_net=TrueraiseExc=FalseprintOutput=Falsenspawn_args=['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11'])
+Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11']
+Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '7aec9502eaf0435d826c713d53e43dc3', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '-a', '-u', 'mockbuild', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', 'bash', '--login', '-c', '/usr/bin/rpmbuild -br --noprep --noclean --target noarch --nodeps /builddir/build/SPECS/python-boto3.spec'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+Building target platforms: noarch
+Building for target noarch
+setting SOURCE_DATE_EPOCH=1742169600
+Executing(%generate_buildrequires): /bin/sh -e /var/tmp/rpm-tmp.vgBNLd
++ umask 022
++ cd /builddir/build/BUILD/python-boto3-1.37.14-build
++ cd boto3-1.37.14
++ echo pyproject-rpm-macros
++ echo python3-devel
++ echo 'python3dist(packaging)'
++ echo 'python3dist(pip) >= 19'
++ '[' -f pyproject.toml ']'
++ echo '(python3dist(tomli) if python3-devel < 3.11)'
++ rm -rfv '*.dist-info/'
++ '[' -f /usr/bin/python3 ']'
++ mkdir -p /builddir/build/BUILD/python-boto3-1.37.14-build/boto3-1.37.14/.pyproject-builddir
++ echo -n
++ CFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -mbranch-protection=standard -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer '
++ CXXFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -mbranch-protection=standard -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer '
++ FFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -mbranch-protection=standard -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -I/usr/lib/gfortran/modules '
++ FCFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -mbranch-protection=standard -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -I/usr/lib/gfortran/modules '
++ VALAFLAGS=-g
++ LDFLAGS='-Wl,-z,relro -Wl,--as-needed   -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -Wl,--build-id=sha1  '
++ LT_SYS_LIBRARY_PATH=/usr/lib:
++ CC=gcc
++ CXX=g++
++ TMPDIR=/builddir/build/BUILD/python-boto3-1.37.14-build/boto3-1.37.14/.pyproject-builddir
++ RPM_TOXENV=py313
++ HOSTNAME=rpmbuild
++ /usr/bin/python3 -Bs /usr/lib/rpm/redhat/pyproject_buildrequires.py --generate-extras --python3_pkgversion 3 --wheeldir /builddir/build/BUILD/python-boto3-1.37.14-build/boto3-1.37.14/pyproject-wheeldir --output /builddir/build/BUILD/python-boto3-1.37.14-build/python-boto3-1.37.14-1.eln147.noarch-pyproject-buildrequires
+Handling setuptools >= 40.8 from default build backend
+Requirement not satisfied: setuptools >= 40.8
+Exiting dependency generation pass: build backend
++ cat /builddir/build/BUILD/python-boto3-1.37.14-build/python-boto3-1.37.14-1.eln147.noarch-pyproject-buildrequires
++ rm -rfv '*.dist-info/'
++ RPM_EC=0
+++ jobs -p
++ exit 0
+Wrote: /builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.buildreqs.nosrc.rpm
+Child return code was: 11
+Dynamic buildrequires detected
+Going to install missing buildrequires. See root.log for details.
+ENTER ['do_with_status'](['bash', '--login', '-c', '/usr/bin/rpmbuild -br --noprep --noclean --target noarch --nodeps /builddir/build/SPECS/python-boto3.spec'], chrootPath='/var/lib/mock/eln-build-side-108102-58033177-6561774/root'env={'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8'}shell=Falselogger=<mockbuild.trace_decorator.getLog object at 0xffffa5fb9590>timeout=201600uid=1000gid=425user='mockbuild'unshare_net=TrueraiseExc=FalseprintOutput=Falsenspawn_args=['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11'])
+Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11']
+Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', 'c42dfaa432a44ec699fdfe0d865be7c2', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '-a', '-u', 'mockbuild', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', 'bash', '--login', '-c', '/usr/bin/rpmbuild -br --noprep --noclean --target noarch --nodeps /builddir/build/SPECS/python-boto3.spec'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+Building target platforms: noarch
+Building for target noarch
+setting SOURCE_DATE_EPOCH=1742169600
+Executing(%generate_buildrequires): /bin/sh -e /var/tmp/rpm-tmp.iFCl1k
++ umask 022
++ cd /builddir/build/BUILD/python-boto3-1.37.14-build
++ cd boto3-1.37.14
++ echo pyproject-rpm-macros
++ echo python3-devel
++ echo 'python3dist(packaging)'
++ echo 'python3dist(pip) >= 19'
++ '[' -f pyproject.toml ']'
++ echo '(python3dist(tomli) if python3-devel < 3.11)'
++ rm -rfv '*.dist-info/'
++ '[' -f /usr/bin/python3 ']'
++ mkdir -p /builddir/build/BUILD/python-boto3-1.37.14-build/boto3-1.37.14/.pyproject-builddir
++ echo -n
++ CFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -mbranch-protection=standard -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer '
++ CXXFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -mbranch-protection=standard -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer '
++ FFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -mbranch-protection=standard -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -I/usr/lib/gfortran/modules '
++ FCFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -mbranch-protection=standard -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -I/usr/lib/gfortran/modules '
++ VALAFLAGS=-g
++ LDFLAGS='-Wl,-z,relro -Wl,--as-needed   -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -Wl,--build-id=sha1  '
++ LT_SYS_LIBRARY_PATH=/usr/lib:
++ CC=gcc
++ CXX=g++
++ TMPDIR=/builddir/build/BUILD/python-boto3-1.37.14-build/boto3-1.37.14/.pyproject-builddir
++ RPM_TOXENV=py313
++ HOSTNAME=rpmbuild
++ /usr/bin/python3 -Bs /usr/lib/rpm/redhat/pyproject_buildrequires.py --generate-extras --python3_pkgversion 3 --wheeldir /builddir/build/BUILD/python-boto3-1.37.14-build/boto3-1.37.14/pyproject-wheeldir --output /builddir/build/BUILD/python-boto3-1.37.14-build/python-boto3-1.37.14-1.eln147.noarch-pyproject-buildrequires
+Handling setuptools >= 40.8 from default build backend
+Requirement satisfied: setuptools >= 40.8
+   (installed: setuptools 74.1.3)
+running egg_info
+creating boto3.egg-info
+writing boto3.egg-info/PKG-INFO
+writing dependency_links to boto3.egg-info/dependency_links.txt
+writing requirements to boto3.egg-info/requires.txt
+writing top-level names to boto3.egg-info/top_level.txt
+writing manifest file 'boto3.egg-info/SOURCES.txt'
+reading manifest file 'boto3.egg-info/SOURCES.txt'
+reading manifest template 'MANIFEST.in'
+adding license file 'LICENSE'
+adding license file 'NOTICE'
+writing manifest file 'boto3.egg-info/SOURCES.txt'
+running dist_info
+writing boto3.egg-info/PKG-INFO
+writing dependency_links to boto3.egg-info/dependency_links.txt
+writing requirements to boto3.egg-info/requires.txt
+writing top-level names to boto3.egg-info/top_level.txt
+reading manifest file 'boto3.egg-info/SOURCES.txt'
+reading manifest template 'MANIFEST.in'
+adding license file 'LICENSE'
+adding license file 'NOTICE'
+writing manifest file 'boto3.egg-info/SOURCES.txt'
+creating '/builddir/build/BUILD/python-boto3-1.37.14-build/boto3-1.37.14/boto3-1.37.14.dist-info'
+Handling botocore <1.38.0,>=1.37.14 from hook generated metadata: Requires-Dist (boto3)
+Requirement not satisfied: botocore <1.38.0,>=1.37.14
+Handling jmespath <2.0.0,>=0.7.1 from hook generated metadata: Requires-Dist (boto3)
+Requirement not satisfied: jmespath <2.0.0,>=0.7.1
+Handling s3transfer <0.12.0,>=0.11.0 from hook generated metadata: Requires-Dist (boto3)
+Requirement not satisfied: s3transfer <0.12.0,>=0.11.0
+Handling botocore[crt] <2.0a0,>=1.21.0 ; extra == 'crt' from hook generated metadata: Requires-Dist (boto3)
+Ignoring alien requirement: botocore[crt] <2.0a0,>=1.21.0 ; extra == 'crt'
++ cat /builddir/build/BUILD/python-boto3-1.37.14-build/python-boto3-1.37.14-1.eln147.noarch-pyproject-buildrequires
++ rm -rfv boto3-1.37.14.dist-info/
+removed 'boto3-1.37.14.dist-info/top_level.txt'
+removed 'boto3-1.37.14.dist-info/METADATA'
+removed 'boto3-1.37.14.dist-info/LICENSE'
+removed 'boto3-1.37.14.dist-info/NOTICE'
+removed directory 'boto3-1.37.14.dist-info/'
++ RPM_EC=0
+++ jobs -p
++ exit 0
+Wrote: /builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.buildreqs.nosrc.rpm
+Child return code was: 11
+Dynamic buildrequires detected
+Going to install missing buildrequires. See root.log for details.

--- a/data/0005/root.log
+++ b/data/0005/root.log
@@ -1,0 +1,3300 @@
+INFO buildroot.py:665:  Mock Version: 6.0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/results
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/results
+INFO buildroot.py:316:  calling preinit hooks
+DEBUG buildroot.py:721:  create skeleton dirs
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/rpm
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/yum
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/dbus
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/dbus
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/log
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/log
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/cache/dnf
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/cache/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/cache/yum
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/cache/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/rpm
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/tmp
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/tmp/ccache
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/tmp/ccache
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/tmp
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf/vars
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf/vars
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum.repos.d
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum.repos.d
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/pts
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/pts
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/shm
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/shm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/mapper
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/mapper
+DEBUG buildroot.py:865:  kernel version == 6.12.10-200.fc41.aarch64
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/fstab
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum/yum.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf/dnf.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/log/yum.log
+DEBUG buildroot.py:330:  rootdir = /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root
+DEBUG buildroot.py:331:  resultdir = /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/results
+DEBUG package_manager.py:63:  searching for 'dnf5' package manager or alternatives
+INFO buildroot.py:179:  Package manager dnf5 detected and used (fallback)
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/mock
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/mock
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust with files from /etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/./extracted
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/./extracted
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/./source
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/./source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/edk2
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/edk2
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/java
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/java
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/openssl
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/openssl
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/pem
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/pem
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/pem/directory-hash
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/pem/directory-hash
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/source/anchors
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/source/anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/source/blocklist
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/source/blocklist
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source with files from /usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source/./anchors
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source/./anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source/./blocklist
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source/./blocklist
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share
+DEBUG package_manager.py:388:  Copying /usr/share/distribution-gpg-keys to the bootstrap chroot
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['cp', '-a', '/usr/share/distribution-gpg-keys', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf
+DEBUG package_manager.py:689:  configure DNF vars
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/proc', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/sys', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/shm
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/pts
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'devpts', '-o', 'gid=5,mode=0620,ptmxmode=0666,newinstance', 'devpts', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'bind', '/tmp/mock-selinux-plugin.z2jd746g', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys/fs/selinux
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/installation-homedir
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/installation-homedir
+DEBUG package_manager.py:295:  ['/usr/bin/dnf5', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/', 'install', 'dnf5', 'dnf5-plugins', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing']
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/usr/bin/dnf5', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/', 'install', 'dnf5', 'dnf5-plugins', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing', '--setopt=tsflags=nocontexts'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/installation-homedir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'LC_MESSAGES': 'C.UTF-8'} and shell False
+DEBUG util.py:459:  Updating and loading repositories:
+DEBUG util.py:459:   build                                  100% |  48.9 MiB/s |  14.2 MiB |  00m00s
+DEBUG util.py:459:  Repositories loaded.
+DEBUG util.py:461:  Package                      Arch    Version                      Repository      Size
+DEBUG util.py:461:  Installing:
+DEBUG util.py:461:   dnf5                        aarch64 5.2.11.0-1.eln146            build        2.2 MiB
+DEBUG util.py:461:   dnf5-plugins                aarch64 5.2.11.0-1.eln146            build        1.3 MiB
+DEBUG util.py:461:  Installing dependencies:
+DEBUG util.py:461:   alternatives                aarch64 1.32-1.eln146                build       90.2 KiB
+DEBUG util.py:461:   audit-libs                  aarch64 4.0.3-2.eln145               build      419.2 KiB
+DEBUG util.py:461:   bash                        aarch64 5.2.37-3.eln146              build        8.2 MiB
+DEBUG util.py:461:   bzip2-libs                  aarch64 1.0.8-20.eln145              build       72.6 KiB
+DEBUG util.py:461:   ca-certificates             noarch  2024.2.69_v8.0.401-5.eln145  build        2.6 MiB
+DEBUG util.py:461:   coreutils-single            aarch64 9.6-2.eln146                 build        1.4 MiB
+DEBUG util.py:461:   crypto-policies             noarch  20250214-1.gitfd9b9b9.eln146 build      109.2 KiB
+DEBUG util.py:461:   curl                        aarch64 8.13.0~rc1-2.eln146          build      457.0 KiB
+DEBUG util.py:461:   cyrus-sasl-lib              aarch64 2.1.28-30.eln145             build      907.7 KiB
+DEBUG util.py:461:   elfutils-default-yama-scope noarch  0.192-8.eln145               build        1.8 KiB
+DEBUG util.py:461:   elfutils-libelf             aarch64 0.192-8.eln145               build        1.2 MiB
+DEBUG util.py:461:   elfutils-libs               aarch64 0.192-8.eln145               build      746.4 KiB
+DEBUG util.py:461:   fedora-gpg-keys             noarch  43-0.1.eln146                build      128.2 KiB
+DEBUG util.py:461:   fedora-release-common       noarch  43-0.7.eln147                build       20.4 KiB
+DEBUG util.py:461:   fedora-release-eln          noarch  43-0.7.eln147                build        0.0   B
+DEBUG util.py:461:   fedora-release-identity-eln noarch  43-0.7.eln147                build        1.7 KiB
+DEBUG util.py:461:   fedora-repos-eln            noarch  43-0.1.eln146                build       10.9 KiB
+DEBUG util.py:461:   file-libs                   aarch64 5.46-1.eln145                build       11.9 MiB
+DEBUG util.py:461:   filesystem                  aarch64 3.18-38.eln146               build      112.0   B
+DEBUG util.py:461:   findutils                   aarch64 1:4.10.0-5.eln145            build        1.9 MiB
+DEBUG util.py:461:   fmt                         aarch64 11.1.4-1.eln146              build      259.4 KiB
+DEBUG util.py:461:   gdbm-libs                   aarch64 1:1.23-9.eln145              build      234.0 KiB
+DEBUG util.py:461:   glib2                       aarch64 2.84.0-1.eln146              build       15.3 MiB
+DEBUG util.py:461:   glibc                       aarch64 2.41.9000-2.eln146           build        6.3 MiB
+DEBUG util.py:461:   glibc-common                aarch64 2.41.9000-2.eln146           build        1.3 MiB
+DEBUG util.py:461:   glibc-minimal-langpack      aarch64 2.41.9000-2.eln146           build        0.0   B
+DEBUG util.py:461:   gnutls                      aarch64 3.8.9-5.eln146               build        3.4 MiB
+DEBUG util.py:461:   grep                        aarch64 3.11-10.eln145               build        1.0 MiB
+DEBUG util.py:461:   json-c                      aarch64 0.18-2.eln145                build      138.7 KiB
+DEBUG util.py:461:   keyutils-libs               aarch64 1.6.3-5.eln145               build       98.3 KiB
+DEBUG util.py:461:   krb5-libs                   aarch64 1.21.3-5.eln145              build        2.5 MiB
+DEBUG util.py:461:   libacl                      aarch64 2.3.2-3.eln145               build       67.9 KiB
+DEBUG util.py:461:   libarchive                  aarch64 3.7.7-4.eln146               build      910.6 KiB
+DEBUG util.py:461:   libattr                     aarch64 2.5.2-5.eln145               build       68.5 KiB
+DEBUG util.py:461:   libblkid                    aarch64 2.40.4-7.eln146              build      290.5 KiB
+DEBUG util.py:461:   libbrotli                   aarch64 1.1.0-6.eln145               build      909.5 KiB
+DEBUG util.py:461:   libcap                      aarch64 2.73-2.eln145                build      506.8 KiB
+DEBUG util.py:461:   libcap-ng                   aarch64 0.8.5-4.eln145               build      161.0 KiB
+DEBUG util.py:461:   libcom_err                  aarch64 1.47.2-3.eln145              build      111.2 KiB
+DEBUG util.py:461:   libcurl                     aarch64 8.13.0~rc1-2.eln146          build      858.5 KiB
+DEBUG util.py:461:   libdnf5                     aarch64 5.2.11.0-1.eln146            build        3.3 MiB
+DEBUG util.py:461:   libdnf5-cli                 aarch64 5.2.11.0-1.eln146            build      864.5 KiB
+DEBUG util.py:461:   libeconf                    aarch64 0.7.6-1.eln146               build       80.6 KiB
+DEBUG util.py:461:   libevent                    aarch64 2.1.12-15.eln145             build        1.1 MiB
+DEBUG util.py:461:   libffi                      aarch64 3.4.7-2.eln146               build      154.7 KiB
+DEBUG util.py:461:   libgcc                      aarch64 15.0.1-0.10.eln146           build      222.2 KiB
+DEBUG util.py:461:   libgomp                     aarch64 15.0.1-0.10.eln146           build      511.4 KiB
+DEBUG util.py:461:   libidn2                     aarch64 2.3.8-1.eln146               build      560.6 KiB
+DEBUG util.py:461:   libmodulemd                 aarch64 2.15.0-16.eln145             build      723.6 KiB
+DEBUG util.py:461:   libmount                    aarch64 2.40.4-7.eln146              build      355.8 KiB
+DEBUG util.py:461:   libnghttp2                  aarch64 1.65.0-1.eln146              build      197.9 KiB
+DEBUG util.py:461:   libpsl                      aarch64 0.21.5-5.eln145              build      132.5 KiB
+DEBUG util.py:461:   librepo                     aarch64 1.19.0-3.eln145              build      228.1 KiB
+DEBUG util.py:461:   libselinux                  aarch64 3.8-1.eln145                 build      201.1 KiB
+DEBUG util.py:461:   libsemanage                 aarch64 3.8-1.eln145                 build      360.1 KiB
+DEBUG util.py:461:   libsepol                    aarch64 3.8-1.eln145                 build      810.0 KiB
+DEBUG util.py:461:   libsmartcols                aarch64 2.40.4-7.eln146              build      224.4 KiB
+DEBUG util.py:461:   libsolv                     aarch64 0.7.31-5.eln146              build      924.1 KiB
+DEBUG util.py:461:   libssh                      aarch64 0.11.1-4.eln145              build      585.4 KiB
+DEBUG util.py:461:   libssh-config               noarch  0.11.1-4.eln145              build      277.0   B
+DEBUG util.py:461:   libstdc++                   aarch64 15.0.1-0.10.eln146           build        2.9 MiB
+DEBUG util.py:461:   libtasn1                    aarch64 4.20.0-1.eln146              build      220.4 KiB
+DEBUG util.py:461:   libtool-ltdl                aarch64 2.5.4-4.eln145               build       94.0 KiB
+DEBUG util.py:461:   libunistring                aarch64 1.1-9.eln145                 build        1.7 MiB
+DEBUG util.py:461:   libuuid                     aarch64 2.40.4-7.eln146              build       69.4 KiB
+DEBUG util.py:461:   libverto                    aarch64 0.3.2-10.eln145              build       69.4 KiB
+DEBUG util.py:461:   libxcrypt                   aarch64 4.4.38-6.eln146              build      272.1 KiB
+DEBUG util.py:461:   libxml2                     aarch64 2.12.10-1.eln146             build        1.9 MiB
+DEBUG util.py:461:   libyaml                     aarch64 0.2.5-16.eln145              build      134.5 KiB
+DEBUG util.py:461:   libzstd                     aarch64 1.5.7-1.eln146               build      667.7 KiB
+DEBUG util.py:461:   lua-libs                    aarch64 5.4.7-3.eln146               build      328.9 KiB
+DEBUG util.py:461:   lz4-libs                    aarch64 1.10.0-2.eln145              build      197.4 KiB
+DEBUG util.py:461:   ncurses-base                noarch  6.5-5.20250125.eln145        build      326.8 KiB
+DEBUG util.py:461:   ncurses-libs                aarch64 6.5-5.20250125.eln145        build        1.2 MiB
+DEBUG util.py:461:   nettle                      aarch64 3.10.1-1.eln146              build      959.2 KiB
+DEBUG util.py:461:   openldap                    aarch64 2.6.9-3.eln145               build      697.3 KiB
+DEBUG util.py:461:   openssl-libs                aarch64 1:3.2.4-3.eln146             build        6.3 MiB
+DEBUG util.py:461:   p11-kit                     aarch64 0.25.5-5.eln145              build        2.4 MiB
+DEBUG util.py:461:   p11-kit-trust               aarch64 0.25.5-5.eln145              build      463.3 KiB
+DEBUG util.py:461:   pam-libs                    aarch64 1.7.0-4.eln145               build      222.9 KiB
+DEBUG util.py:461:   pcre2                       aarch64 10.45-1.eln146               build      713.6 KiB
+DEBUG util.py:461:   pcre2-syntax                noarch  10.45-1.eln146               build      273.9 KiB
+DEBUG util.py:461:   popt                        aarch64 1.19-8.eln145                build      144.8 KiB
+DEBUG util.py:461:   publicsuffix-list-dafsa     noarch  20250116-1.eln145            build       68.5 KiB
+DEBUG util.py:461:   rpm                         aarch64 4.20.1-1.eln146              build        3.3 MiB
+DEBUG util.py:461:   rpm-build-libs              aarch64 4.20.1-1.eln146              build      198.6 KiB
+DEBUG util.py:461:   rpm-libs                    aarch64 4.20.1-1.eln146              build      733.6 KiB
+DEBUG util.py:461:   rpm-sequoia                 aarch64 1.7.0-2.eln146               build        2.3 MiB
+DEBUG util.py:461:   sdbus-cpp                   aarch64 1.5.0-4.eln145               build      301.7 KiB
+DEBUG util.py:461:   sed                         aarch64 4.9-4.eln145                 build      873.2 KiB
+DEBUG util.py:461:   setup                       noarch  2.15.0-14.eln146             build      720.9 KiB
+DEBUG util.py:461:   shadow-utils                aarch64 2:4.17.0-4.eln145            build        4.5 MiB
+DEBUG util.py:461:   sqlite-libs                 aarch64 3.49.0-1.eln146              build        1.5 MiB
+DEBUG util.py:461:   systemd-libs                aarch64 257.4-1.eln146               build        2.3 MiB
+DEBUG util.py:461:   systemd-standalone-sysusers aarch64 257.4-1.eln146               build      329.4 KiB
+DEBUG util.py:461:   xz-libs                     aarch64 1:5.6.3-3.eln145             build      202.3 KiB
+DEBUG util.py:461:   zlib-ng-compat              aarch64 2.2.4-2.eln146               build      133.4 KiB
+DEBUG util.py:461:  Transaction Summary:
+DEBUG util.py:461:   Installing:        99 packages
+DEBUG util.py:459:  Total size of inbound packages is 34 MiB. Need to download 34 MiB.
+DEBUG util.py:459:  After this operation, 119 MiB extra will be used (install 119 MiB, remove 0 B).
+DEBUG util.py:459:  [ 1/99] dnf5-plugins-0:5.2.11.0-1.eln14 100% |  14.7 MiB/s | 405.7 KiB |  00m00s
+DEBUG util.py:459:  [ 2/99] dnf5-0:5.2.11.0-1.eln146.aarch6 100% |  24.1 MiB/s | 764.8 KiB |  00m00s
+DEBUG util.py:459:  [ 3/99] fmt-0:11.1.4-1.eln146.aarch64   100% |  15.8 MiB/s |  96.8 KiB |  00m00s
+DEBUG util.py:459:  [ 4/99] bash-0:5.2.37-3.eln146.aarch64  100% |  40.1 MiB/s |   1.8 MiB |  00m00s
+DEBUG util.py:459:  [ 5/99] libdnf5-cli-0:5.2.11.0-1.eln146 100% |  45.5 MiB/s | 326.4 KiB |  00m00s
+DEBUG util.py:459:  [ 6/99] libdnf5-0:5.2.11.0-1.eln146.aar 100% |  52.0 MiB/s |   1.1 MiB |  00m00s
+DEBUG util.py:459:  [ 7/99] libgcc-0:15.0.1-0.10.eln146.aar 100% |  16.9 MiB/s | 104.1 KiB |  00m00s
+DEBUG util.py:459:  [ 8/99] glibc-0:2.41.9000-2.eln146.aarc 100% |  57.1 MiB/s |   1.9 MiB |  00m00s
+DEBUG util.py:459:  [ 9/99] rpm-libs-0:4.20.1-1.eln146.aarc 100% |  37.3 MiB/s | 305.5 KiB |  00m00s
+DEBUG util.py:459:  [10/99] sdbus-cpp-0:1.5.0-4.eln145.aarc 100% |  20.0 MiB/s | 102.2 KiB |  00m00s
+DEBUG util.py:459:  [11/99] libstdc++-0:15.0.1-0.10.eln146. 100% |  51.9 MiB/s | 850.5 KiB |  00m00s
+DEBUG util.py:459:  [12/99] json-c-0:0.18-2.eln145.aarch64  100% |   8.8 MiB/s |  44.9 KiB |  00m00s
+DEBUG util.py:459:  [13/99] systemd-libs-0:257.4-1.eln146.a 100% |  69.0 MiB/s | 777.1 KiB |  00m00s
+DEBUG util.py:459:  [14/99] rpm-build-libs-0:4.20.1-1.eln14 100% |  13.2 MiB/s |  94.3 KiB |  00m00s
+DEBUG util.py:459:  [15/99] zlib-ng-compat-0:2.2.4-2.eln146 100% |   9.2 MiB/s |  65.9 KiB |  00m00s
+DEBUG util.py:459:  [16/99] ncurses-libs-0:6.5-5.20250125.e 100% |  39.6 MiB/s | 324.5 KiB |  00m00s
+DEBUG util.py:459:  [17/99] glibc-common-0:2.41.9000-2.eln1 100% |  38.8 MiB/s | 397.6 KiB |  00m00s
+DEBUG util.py:459:  [18/99] filesystem-0:3.18-38.eln146.aar 100% |  69.2 MiB/s |   1.3 MiB |  00m00s
+DEBUG util.py:459:  [19/99] libmodulemd-0:2.15.0-16.eln145. 100% |  25.4 MiB/s | 208.2 KiB |  00m00s
+DEBUG util.py:459:  [20/99] librepo-0:1.19.0-3.eln145.aarch 100% |  18.0 MiB/s |  92.2 KiB |  00m00s
+DEBUG util.py:459:  [21/99] libsolv-0:0.7.31-5.eln146.aarch 100% |  49.9 MiB/s | 409.2 KiB |  00m00s
+DEBUG util.py:459:  [22/99] libxml2-0:2.12.10-1.eln146.aarc 100% |  60.3 MiB/s | 679.7 KiB |  00m00s
+DEBUG util.py:459:  [23/99] glib2-0:2.84.0-1.eln146.aarch64 100% |  81.6 MiB/s |   3.0 MiB |  00m00s
+DEBUG util.py:459:  [24/99] libsmartcols-0:2.40.4-7.eln146. 100% |   7.8 MiB/s |  79.4 KiB |  00m00s
+DEBUG util.py:459:  [25/99] sqlite-libs-0:3.49.0-1.eln146.a 100% |  38.2 MiB/s | 744.1 KiB |  00m00s
+DEBUG util.py:459:  [26/99] bzip2-libs-0:1.0.8-20.eln145.aa 100% |   8.0 MiB/s |  41.2 KiB |  00m00s
+DEBUG util.py:459:  [27/99] libacl-0:2.3.2-3.eln145.aarch64 100% |   4.8 MiB/s |  24.4 KiB |  00m00s
+DEBUG util.py:459:  [28/99] libcap-0:2.73-2.eln145.aarch64  100% |  16.7 MiB/s |  85.4 KiB |  00m00s
+DEBUG util.py:459:  [29/99] lua-libs-0:5.4.7-3.eln146.aarch 100% |  25.1 MiB/s | 128.4 KiB |  00m00s
+DEBUG util.py:459:  [30/99] libzstd-0:1.5.7-1.eln146.aarch6 100% |  34.6 MiB/s | 283.1 KiB |  00m00s
+DEBUG util.py:459:  [31/99] popt-0:1.19-8.eln145.aarch64    100% |  14.4 MiB/s |  58.9 KiB |  00m00s
+DEBUG util.py:459:  [32/99] rpm-0:4.20.1-1.eln146.aarch64   100% |  84.3 MiB/s | 517.7 KiB |  00m00s
+DEBUG util.py:459:  [33/99] xz-libs-1:5.6.3-3.eln145.aarch6 100% |  21.7 MiB/s | 111.0 KiB |  00m00s
+DEBUG util.py:459:  [34/99] elfutils-libelf-0:0.192-8.eln14 100% |  40.5 MiB/s | 207.2 KiB |  00m00s
+DEBUG util.py:459:  [35/99] rpm-sequoia-0:1.7.0-2.eln146.aa 100% |  61.1 MiB/s | 875.2 KiB |  00m00s
+DEBUG util.py:459:  [36/99] elfutils-libs-0:0.192-8.eln145. 100% |  31.7 MiB/s | 260.1 KiB |  00m00s
+DEBUG util.py:459:  [37/99] libgomp-0:15.0.1-0.10.eln146.aa 100% |  56.3 MiB/s | 346.0 KiB |  00m00s
+DEBUG util.py:459:  [38/99] setup-0:2.15.0-14.eln146.noarch 100% |  29.2 MiB/s | 149.7 KiB |  00m00s
+DEBUG util.py:459:  [39/99] file-libs-0:5.46-1.eln145.aarch 100% |  59.1 MiB/s | 847.6 KiB |  00m00s
+DEBUG util.py:459:  [40/99] ncurses-base-0:6.5-5.20250125.e 100% |  12.4 MiB/s |  63.6 KiB |  00m00s
+DEBUG util.py:459:  [41/99] libffi-0:3.4.7-2.eln146.aarch64 100% |   7.5 MiB/s |  38.6 KiB |  00m00s
+DEBUG util.py:459:  [42/99] libmount-0:2.40.4-7.eln146.aarc 100% |  29.3 MiB/s | 149.8 KiB |  00m00s
+DEBUG util.py:459:  [43/99] gnutls-0:3.8.9-5.eln146.aarch64 100% |  77.8 MiB/s |   1.1 MiB |  00m00s
+DEBUG util.py:459:  [44/99] libselinux-0:3.8-1.eln145.aarch 100% |  11.7 MiB/s |  95.9 KiB |  00m00s
+DEBUG util.py:459:  [45/99] pcre2-0:10.45-1.eln146.aarch64  100% |  39.5 MiB/s | 242.7 KiB |  00m00s
+DEBUG util.py:459:  [46/99] libyaml-0:0.2.5-16.eln145.aarch 100% |  14.1 MiB/s |  57.9 KiB |  00m00s
+DEBUG util.py:459:  [47/99] libattr-0:2.5.2-5.eln145.aarch6 100% |   5.8 MiB/s |  17.8 KiB |  00m00s
+DEBUG util.py:459:  [48/99] pam-libs-0:1.7.0-4.eln145.aarch 100% |   9.5 MiB/s |  58.1 KiB |  00m00s
+DEBUG util.py:459:  [49/99] curl-0:8.13.0~rc1-2.eln146.aarc 100% |  36.5 MiB/s | 224.5 KiB |  00m00s
+DEBUG util.py:459:  [50/99] elfutils-default-yama-scope-0:0 100% |   4.1 MiB/s |  12.7 KiB |  00m00s
+DEBUG util.py:459:  [51/99] libarchive-0:3.7.7-4.eln146.aar 100% |  44.0 MiB/s | 405.7 KiB |  00m00s
+DEBUG util.py:459:  [52/99] crypto-policies-0:20250214-1.gi 100% |  15.9 MiB/s |  65.0 KiB |  00m00s
+DEBUG util.py:459:  [53/99] openssl-libs-1:3.2.4-3.eln146.a 100% |  80.7 MiB/s |   2.2 MiB |  00m00s
+DEBUG util.py:459:  [54/99] libtasn1-0:4.20.0-1.eln146.aarc 100% |  10.3 MiB/s |  73.7 KiB |  00m00s
+DEBUG util.py:459:  [55/99] libidn2-0:2.3.8-1.eln146.aarch6 100% |  15.0 MiB/s | 168.8 KiB |  00m00s
+DEBUG util.py:459:  [56/99] libunistring-0:1.1-9.eln145.aar 100% |  58.5 MiB/s | 539.4 KiB |  00m00s
+DEBUG util.py:459:  [57/99] nettle-0:3.10.1-1.eln146.aarch6 100% |  46.2 MiB/s | 520.6 KiB |  00m00s
+DEBUG util.py:459:  [58/99] p11-kit-0:0.25.5-5.eln145.aarch 100% |  37.3 MiB/s | 458.5 KiB |  00m00s
+DEBUG util.py:459:  [59/99] p11-kit-trust-0:0.25.5-5.eln145 100% |  18.3 MiB/s | 131.2 KiB |  00m00s
+DEBUG util.py:459:  [60/99] libblkid-0:2.40.4-7.eln146.aarc 100% |  23.5 MiB/s | 120.5 KiB |  00m00s
+DEBUG util.py:459:  [61/99] libuuid-0:2.40.4-7.eln146.aarch 100% |   6.2 MiB/s |  25.3 KiB |  00m00s
+DEBUG util.py:459:  [62/99] pcre2-syntax-0:10.45-1.eln146.n 100% |  39.5 MiB/s | 161.8 KiB |  00m00s
+DEBUG util.py:459:  [63/99] libsepol-0:3.8-1.eln145.aarch64 100% |  39.6 MiB/s | 324.1 KiB |  00m00s
+DEBUG util.py:459:  [64/99] audit-libs-0:4.0.3-2.eln145.aar 100% |  21.2 MiB/s | 130.0 KiB |  00m00s
+DEBUG util.py:459:  [65/99] libeconf-0:0.7.6-1.eln146.aarch 100% |   6.9 MiB/s |  35.3 KiB |  00m00s
+DEBUG util.py:459:  [66/99] ca-certificates-0:2024.2.69_v8. 100% |  61.5 MiB/s | 945.1 KiB |  00m00s
+DEBUG util.py:459:  [67/99] alternatives-0:1.32-1.eln146.aa 100% |  10.0 MiB/s |  40.8 KiB |  00m00s
+DEBUG util.py:459:  [68/99] lz4-libs-0:1.10.0-2.eln145.aarc 100% |  11.1 MiB/s |  79.6 KiB |  00m00s
+DEBUG util.py:459:  [69/99] grep-0:3.11-10.eln145.aarch64   100% |  46.6 MiB/s | 286.5 KiB |  00m00s
+DEBUG util.py:459:  [70/99] findutils-1:4.10.0-5.eln145.aar 100% |  59.2 MiB/s | 545.7 KiB |  00m00s
+DEBUG util.py:459:  [71/99] sed-0:4.9-4.eln145.aarch64      100% |  33.2 MiB/s | 306.3 KiB |  00m00s
+DEBUG util.py:459:  [72/99] libcap-ng-0:0.8.5-4.eln145.aarc 100% |   6.3 MiB/s |  32.3 KiB |  00m00s
+DEBUG util.py:459:  [73/99] fedora-release-eln-0:43-0.7.eln 100% |   3.7 MiB/s |  15.0 KiB |  00m00s
+DEBUG util.py:459:  [74/99] fedora-release-common-0:43-0.7. 100% |   8.4 MiB/s |  25.9 KiB |  00m00s
+DEBUG util.py:459:  [75/99] fedora-repos-eln-0:43-0.1.eln14 100% |   4.6 MiB/s |   9.4 KiB |  00m00s
+DEBUG util.py:459:  [76/99] fedora-release-identity-eln-0:4 100% |   5.7 MiB/s |  17.4 KiB |  00m00s
+DEBUG util.py:459:  [77/99] fedora-gpg-keys-0:43-0.1.eln146 100% |  30.6 MiB/s | 125.3 KiB |  00m00s
+DEBUG util.py:459:  [78/99] systemd-standalone-sysusers-0:2 100% |  24.6 MiB/s | 151.2 KiB |  00m00s
+DEBUG util.py:459:  [79/99] libxcrypt-0:4.4.38-6.eln146.aar 100% |  20.2 MiB/s | 124.2 KiB |  00m00s
+DEBUG util.py:459:  [80/99] coreutils-single-0:9.6-2.eln146 100% |  68.5 MiB/s | 631.6 KiB |  00m00s
+DEBUG util.py:459:  [81/99] libcurl-0:8.13.0~rc1-2.eln146.a 100% |  36.9 MiB/s | 377.4 KiB |  00m00s
+DEBUG util.py:459:  [82/99] libbrotli-0:1.1.0-6.eln145.aarc 100% |  47.5 MiB/s | 340.6 KiB |  00m00s
+DEBUG util.py:459:  [83/99] krb5-libs-0:1.21.3-5.eln145.aar 100% |  48.9 MiB/s | 750.6 KiB |  00m00s
+DEBUG util.py:459:  [84/99] libnghttp2-0:1.65.0-1.eln146.aa 100% |  10.1 MiB/s |  72.5 KiB |  00m00s
+DEBUG util.py:459:  [85/99] libpsl-0:0.21.5-5.eln145.aarch6 100% |  12.7 MiB/s |  64.9 KiB |  00m00s
+DEBUG util.py:459:  [86/99] openldap-0:2.6.9-3.eln145.aarch 100% |  49.2 MiB/s | 251.8 KiB |  00m00s
+DEBUG util.py:459:  [87/99] keyutils-libs-0:1.6.3-5.eln145. 100% |   6.2 MiB/s |  31.7 KiB |  00m00s
+DEBUG util.py:459:  [88/99] libssh-0:0.11.1-4.eln145.aarch6 100% |  25.0 MiB/s | 230.4 KiB |  00m00s
+DEBUG util.py:459:  [89/99] libverto-0:0.3.2-10.eln145.aarc 100% |   4.1 MiB/s |  20.8 KiB |  00m00s
+DEBUG util.py:459:  [90/99] libcom_err-0:1.47.2-3.eln145.aa 100% |   3.7 MiB/s |  26.8 KiB |  00m00s
+DEBUG util.py:459:  [91/99] publicsuffix-list-dafsa-0:20250 100% |   9.6 MiB/s |  58.8 KiB |  00m00s
+DEBUG util.py:459:  [92/99] libssh-config-0:0.11.1-4.eln145 100% |   2.2 MiB/s |   9.1 KiB |  00m00s
+DEBUG util.py:459:  [93/99] cyrus-sasl-lib-0:2.1.28-30.eln1 100% |  24.8 MiB/s | 101.6 KiB |  00m00s
+DEBUG util.py:459:  [94/99] libevent-0:2.1.12-15.eln145.aar 100% |  41.5 MiB/s | 254.7 KiB |  00m00s
+DEBUG util.py:459:  [95/99] libtool-ltdl-0:2.5.4-4.eln145.a 100% |   5.8 MiB/s |  35.4 KiB |  00m00s
+DEBUG util.py:459:  [96/99] gdbm-libs-1:1.23-9.eln145.aarch 100% |  11.0 MiB/s |  56.2 KiB |  00m00s
+DEBUG util.py:459:  [97/99] libsemanage-0:3.8-1.eln145.aarc 100% |  19.3 MiB/s | 118.8 KiB |  00m00s
+DEBUG util.py:459:  [98/99] shadow-utils-2:4.17.0-4.eln145. 100% |  83.3 MiB/s |   1.2 MiB |  00m00s
+DEBUG util.py:459:  [99/99] glibc-minimal-langpack-0:2.41.9 100% |  17.8 MiB/s | 127.8 KiB |  00m00s
+DEBUG util.py:459:  --------------------------------------------------------------------------------
+DEBUG util.py:459:  [99/99] Total                           100% | 102.1 MiB/s |  34.3 MiB |  00m00s
+DEBUG util.py:459:  Running transaction
+DEBUG util.py:459:  [  1/101] Verify package files          100% | 697.0   B/s |  99.0   B |  00m00s
+DEBUG util.py:459:  [  2/101] Prepare transaction           100% |   2.1 KiB/s |  99.0   B |  00m00s
+DEBUG util.py:459:  [  3/101] Installing libgcc-0:15.0.1-0. 100% |  54.7 MiB/s | 223.9 KiB |  00m00s
+DEBUG util.py:459:  [  4/101] Installing libssh-config-0:0. 100% | 398.4 KiB/s | 816.0   B |  00m00s
+DEBUG util.py:459:  [  5/101] Installing publicsuffix-list- 100% |  33.8 MiB/s |  69.2 KiB |  00m00s
+DEBUG util.py:459:  [  6/101] Installing fedora-release-ide 100% |   1.2 MiB/s |   2.5 KiB |  00m00s
+DEBUG util.py:459:  [  7/101] Installing fedora-gpg-keys-0: 100% |   7.4 MiB/s | 174.8 KiB |  00m00s
+DEBUG util.py:459:  [  8/101] Installing fedora-release-com 100% |   6.0 MiB/s |  24.7 KiB |  00m00s
+DEBUG util.py:459:  [  9/101] Installing fedora-repos-eln-0 100% |   5.5 MiB/s |  11.2 KiB |  00m00s
+DEBUG util.py:459:  [ 10/101] Installing fedora-release-eln 100% | 121.1 KiB/s | 124.0   B |  00m00s
+DEBUG util.py:459:  [ 11/101] Installing setup-0:2.15.0-14. 100% |  33.8 MiB/s | 726.7 KiB |  00m00s
+DEBUG util.py:459:  >>> [RPM] /etc/hosts created as /etc/hosts.rpmnew
+DEBUG util.py:459:  [ 12/101] Installing filesystem-0:3.18- 100% |   1.3 MiB/s | 212.4 KiB |  00m00s
+DEBUG util.py:459:  [ 13/101] Installing pcre2-syntax-0:10. 100% |  67.5 MiB/s | 276.4 KiB |  00m00s
+DEBUG util.py:459:  [ 14/101] Installing ncurses-base-0:6.5 100% |  19.1 MiB/s | 352.2 KiB |  00m00s
+DEBUG util.py:459:  [ 15/101] Installing ncurses-libs-0:6.5 100% | 113.4 MiB/s |   1.2 MiB |  00m00s
+DEBUG util.py:459:  [ 16/101] Installing glibc-0:2.41.9000- 100% | 102.7 MiB/s |   6.3 MiB |  00m00s
+DEBUG util.py:459:  [ 17/101] Installing bash-0:5.2.37-3.el 100% | 126.0 MiB/s |   8.2 MiB |  00m00s
+DEBUG util.py:459:  [ 18/101] Installing glibc-common-0:2.4 100% |  45.7 MiB/s |   1.3 MiB |  00m00s
+DEBUG util.py:459:  [ 19/101] Installing glibc-minimal-lang 100% |  60.5 KiB/s | 124.0   B |  00m00s
+DEBUG util.py:459:  [ 20/101] Installing zlib-ng-compat-0:2 100% |  43.7 MiB/s | 134.3 KiB |  00m00s
+DEBUG util.py:459:  [ 21/101] Installing libstdc++-0:15.0.1 100% | 207.2 MiB/s |   2.9 MiB |  00m00s
+DEBUG util.py:459:  [ 22/101] Installing bzip2-libs-0:1.0.8 100% |  36.0 MiB/s |  73.8 KiB |  00m00s
+DEBUG util.py:459:  [ 23/101] Installing libzstd-0:1.5.7-1. 100% | 130.7 MiB/s | 669.0 KiB |  00m00s
+DEBUG util.py:459:  [ 24/101] Installing xz-libs-1:5.6.3-3. 100% |  66.2 MiB/s | 203.4 KiB |  00m00s
+DEBUG util.py:459:  [ 25/101] Installing libxml2-0:2.12.10- 100% |  67.6 MiB/s |   1.9 MiB |  00m00s
+DEBUG util.py:459:  [ 26/101] Installing fmt-0:11.1.4-1.eln 100% |  13.4 MiB/s | 260.9 KiB |  00m00s
+DEBUG util.py:459:  [ 27/101] Installing crypto-policies-0: 100% |   7.6 MiB/s | 131.6 KiB |  00m00s
+DEBUG util.py:459:  [ 28/101] Installing json-c-0:0.18-2.el 100% |  45.6 MiB/s | 139.9 KiB |  00m00s
+DEBUG util.py:459:  [ 29/101] Installing popt-0:1.19-8.eln1 100% |  18.5 MiB/s | 151.4 KiB |  00m00s
+DEBUG util.py:459:  [ 30/101] Installing libffi-0:3.4.7-2.e 100% |  50.8 MiB/s | 156.1 KiB |  00m00s
+DEBUG util.py:459:  [ 31/101] Installing pcre2-0:10.45-1.el 100% | 139.7 MiB/s | 715.0 KiB |  00m00s
+DEBUG util.py:459:  [ 32/101] Installing libtasn1-0:4.20.0- 100% |  54.2 MiB/s | 222.2 KiB |  00m00s
+DEBUG util.py:459:  [ 33/101] Installing p11-kit-0:0.25.5-5 100% |  57.0 MiB/s |   2.4 MiB |  00m00s
+DEBUG util.py:459:  [ 34/101] Installing libunistring-0:1.1 100% | 194.0 MiB/s |   1.7 MiB |  00m00s
+DEBUG util.py:459:  [ 35/101] Installing libidn2-0:2.3.8-1. 100% |  69.2 MiB/s | 566.7 KiB |  00m00s
+DEBUG util.py:459:  [ 36/101] Installing libxcrypt-0:4.4.38 100% |  67.1 MiB/s | 274.8 KiB |  00m00s
+DEBUG util.py:459:  [ 37/101] Installing elfutils-libelf-0: 100% | 169.9 MiB/s |   1.2 MiB |  00m00s
+DEBUG util.py:459:  [ 38/101] Installing sqlite-libs-0:3.49 100% | 166.8 MiB/s |   1.5 MiB |  00m00s
+DEBUG util.py:459:  [ 39/101] Installing lua-libs-0:5.4.7-3 100% |  80.6 MiB/s | 330.1 KiB |  00m00s
+DEBUG util.py:459:  [ 40/101] Installing libattr-0:2.5.2-5. 100% |  33.9 MiB/s |  69.4 KiB |  00m00s
+DEBUG util.py:459:  [ 41/101] Installing libacl-0:2.3.2-3.e 100% |  33.6 MiB/s |  68.8 KiB |  00m00s
+DEBUG util.py:459:  [ 42/101] Installing libuuid-0:2.40.4-7 100% |  22.9 MiB/s |  70.4 KiB |  00m00s
+DEBUG util.py:459:  [ 43/101] Installing libsepol-0:3.8-1.e 100% | 158.4 MiB/s | 811.0 KiB |  00m00s
+DEBUG util.py:459:  [ 44/101] Installing libselinux-0:3.8-1 100% |  65.9 MiB/s | 202.3 KiB |  00m00s
+DEBUG util.py:459:  [ 45/101] Installing libeconf-0:0.7.6-1 100% |  26.8 MiB/s |  82.3 KiB |  00m00s
+DEBUG util.py:459:  [ 46/101] Installing findutils-1:4.10.0 100% |  58.2 MiB/s |   1.9 MiB |  00m00s
+DEBUG util.py:459:  [ 47/101] Installing sed-0:4.9-4.eln145 100% |  29.7 MiB/s | 881.4 KiB |  00m00s
+DEBUG util.py:459:  [ 48/101] Installing libblkid-0:2.40.4- 100% |  71.2 MiB/s | 291.6 KiB |  00m00s
+DEBUG util.py:459:  [ 49/101] Installing libmount-0:2.40.4- 100% |  87.1 MiB/s | 356.9 KiB |  00m00s
+DEBUG util.py:459:  [ 50/101] Installing libpsl-0:0.21.5-5. 100% |  43.5 MiB/s | 133.6 KiB |  00m00s
+DEBUG util.py:459:  [ 51/101] Installing grep-0:3.11-10.eln 100% |  33.4 MiB/s |   1.0 MiB |  00m00s
+DEBUG util.py:459:  [ 52/101] Installing file-libs-0:5.46-1 100% | 383.2 MiB/s |  11.9 MiB |  00m00s
+DEBUG util.py:459:  [ 53/101] Installing elfutils-default-y 100% | 145.9 KiB/s |   2.0 KiB |  00m00s
+DEBUG util.py:459:  [ 54/101] Installing elfutils-libs-0:0. 100% | 104.4 MiB/s | 748.2 KiB |  00m00s
+DEBUG util.py:459:  [ 55/101] Installing libsmartcols-0:2.4 100% |  73.4 MiB/s | 225.6 KiB |  00m00s
+DEBUG util.py:459:  [ 56/101] Installing libgomp-0:15.0.1-0 100% | 125.2 MiB/s | 512.8 KiB |  00m00s
+DEBUG util.py:459:  [ 57/101] Installing libyaml-0:0.2.5-16 100% |  44.2 MiB/s | 135.8 KiB |  00m00s
+DEBUG util.py:459:  [ 58/101] Installing nettle-0:3.10.1-1. 100% | 134.2 MiB/s | 961.8 KiB |  00m00s
+DEBUG util.py:459:  [ 59/101] Installing lz4-libs-0:1.10.0- 100% |  64.6 MiB/s | 198.5 KiB |  00m00s
+DEBUG util.py:459:  [ 60/101] Installing alternatives-0:1.3 100% |   4.1 MiB/s |  91.8 KiB |  00m00s
+DEBUG util.py:459:  [ 61/101] Installing p11-kit-trust-0:0. 100% |  12.3 MiB/s | 465.0 KiB |  00m00s
+DEBUG util.py:459:  [ 62/101] Installing gnutls-0:3.8.9-5.e 100% | 168.5 MiB/s |   3.4 MiB |  00m00s
+DEBUG util.py:459:  [ 63/101] Installing glib2-0:2.84.0-1.e 100% | 155.2 MiB/s |  15.4 MiB |  00m00s
+DEBUG util.py:459:  [ 64/101] Installing libcap-ng-0:0.8.5- 100% |  53.0 MiB/s | 162.8 KiB |  00m00s
+DEBUG util.py:459:  [ 65/101] Installing audit-libs-0:4.0.3 100% |  68.6 MiB/s | 421.3 KiB |  00m00s
+DEBUG util.py:459:  [ 66/101] Installing pam-libs-0:1.7.0-4 100% |  55.0 MiB/s | 225.3 KiB |  00m00s
+DEBUG util.py:459:  [ 67/101] Installing libcap-0:2.73-2.el 100% |  20.8 MiB/s | 511.8 KiB |  00m00s
+DEBUG util.py:459:  [ 68/101] Installing systemd-libs-0:257 100% | 166.8 MiB/s |   2.3 MiB |  00m00s
+DEBUG util.py:459:  [ 69/101] Installing coreutils-single-0 100% |  40.6 MiB/s |   1.5 MiB |  00m00s
+DEBUG util.py:459:  [ 70/101] Installing sdbus-cpp-0:1.5.0- 100% |  17.4 MiB/s | 303.4 KiB |  00m00s
+DEBUG util.py:459:  [ 71/101] Installing ca-certificates-0: 100% | 738.5 KiB/s |   2.4 MiB |  00m03s
+DEBUG util.py:459:  [ 72/101] Installing openssl-libs-1:3.2 100% | 186.3 MiB/s |   6.3 MiB |  00m00s
+DEBUG util.py:459:  [ 73/101] Installing rpm-sequoia-0:1.7. 100% | 191.7 MiB/s |   2.3 MiB |  00m00s
+DEBUG util.py:459:  [ 74/101] Installing libarchive-0:3.7.7 100% | 127.3 MiB/s | 912.6 KiB |  00m00s
+DEBUG util.py:459:  [ 75/101] Installing libevent-0:2.1.12- 100% | 135.6 MiB/s |   1.1 MiB |  00m00s
+DEBUG util.py:459:  [ 76/101] Installing systemd-standalone 100% |  15.3 MiB/s | 329.9 KiB |  00m00s
+DEBUG util.py:459:  [ 77/101] Installing rpm-libs-0:4.20.1- 100% | 119.6 MiB/s | 735.1 KiB |  00m00s
+DEBUG util.py:459:  [ 78/101] Installing rpm-build-libs-0:4 100% |  64.9 MiB/s | 199.4 KiB |  00m00s
+DEBUG util.py:459:  [ 79/101] Installing libmodulemd-0:2.15 100% |  30.8 MiB/s | 726.0 KiB |  00m00s
+DEBUG util.py:459:  [ 80/101] Installing libsolv-0:0.7.31-5 100% | 129.2 MiB/s | 925.8 KiB |  00m00s
+DEBUG util.py:459:  [ 81/101] Installing libsemanage-0:3.8- 100% |  70.7 MiB/s | 361.8 KiB |  00m00s
+DEBUG util.py:459:  [ 82/101] Installing shadow-utils-2:4.1 100% |  58.3 MiB/s |   4.5 MiB |  00m00s
+DEBUG util.py:459:  [ 83/101] Installing libbrotli-0:1.1.0- 100% | 127.2 MiB/s | 911.7 KiB |  00m00s
+DEBUG util.py:459:  [ 84/101] Installing libnghttp2-0:1.65. 100% |  64.8 MiB/s | 199.0 KiB |  00m00s
+DEBUG util.py:459:  [ 85/101] Installing keyutils-libs-0:1. 100% |  32.5 MiB/s |  99.8 KiB |  00m00s
+DEBUG util.py:459:  [ 86/101] Installing libcom_err-0:1.47. 100% |  36.5 MiB/s | 112.2 KiB |  00m00s
+DEBUG util.py:459:  [ 87/101] Installing libverto-0:0.3.2-1 100% |  23.2 MiB/s |  71.2 KiB |  00m00s
+DEBUG util.py:459:  [ 88/101] Installing krb5-libs-0:1.21.3 100% | 133.3 MiB/s |   2.5 MiB |  00m00s
+DEBUG util.py:459:  [ 89/101] Installing libssh-0:0.11.1-4. 100% | 114.7 MiB/s | 587.5 KiB |  00m00s
+DEBUG util.py:459:  [ 90/101] Installing libtool-ltdl-0:2.5 100% |  31.0 MiB/s |  95.1 KiB |  00m00s
+DEBUG util.py:459:  [ 91/101] Installing gdbm-libs-1:1.23-9 100% |  57.5 MiB/s | 235.7 KiB |  00m00s
+DEBUG util.py:459:  [ 92/101] Installing cyrus-sasl-lib-0:2 100% |  35.7 MiB/s | 913.2 KiB |  00m00s
+DEBUG util.py:459:  [ 93/101] Installing openldap-0:2.6.9-3 100% |  85.6 MiB/s | 701.1 KiB |  00m00s
+DEBUG util.py:459:  [ 94/101] Installing libcurl-0:8.13.0~r 100% | 139.9 MiB/s | 859.6 KiB |  00m00s
+DEBUG util.py:459:  [ 95/101] Installing librepo-0:1.19.0-3 100% |  56.0 MiB/s | 229.3 KiB |  00m00s
+DEBUG util.py:459:  [ 96/101] Installing libdnf5-0:5.2.11.0 100% | 165.4 MiB/s |   3.3 MiB |  00m00s
+DEBUG util.py:459:  >>> [RPM] /etc/dnf/dnf.conf created as /etc/dnf/dnf.conf.rpmnew
+DEBUG util.py:459:  [ 97/101] Installing libdnf5-cli-0:5.2. 100% |  94.2 MiB/s | 868.2 KiB |  00m00s
+DEBUG util.py:459:  [ 98/101] Installing dnf5-0:5.2.11.0-1. 100% |  38.3 MiB/s |   2.2 MiB |  00m00s
+DEBUG util.py:459:  [ 99/101] Installing curl-0:8.13.0~rc1- 100% |  10.9 MiB/s | 459.5 KiB |  00m00s
+DEBUG util.py:459:  [100/101] Installing rpm-0:4.20.1-1.eln 100% |  44.9 MiB/s |   2.7 MiB |  00m00s
+DEBUG util.py:459:  [101/101] Installing dnf5-plugins-0:5.2 100% | 283.2 KiB/s |   1.3 MiB |  00m05s
+DEBUG util.py:459:  Warning: skipped OpenPGP checks for 99 packages from repository: build
+DEBUG util.py:459:  Complete!
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/os-release
+DEBUG buildroot.py:38:  method _setup_build_dirs skipped in bootstrap
+DEBUG buildroot.py:38:  method _make_users skipped in bootstrap
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/.initialized
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/result
+INFO buildroot.py:316:  calling preinit hooks
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/usr/bin/lscpu'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:461:  Architecture:                         aarch64
+DEBUG util.py:461:  CPU op-mode(s):                       32-bit, 64-bit
+DEBUG util.py:461:  Byte Order:                           Little Endian
+DEBUG util.py:461:  CPU(s):                               12
+DEBUG util.py:461:  On-line CPU(s) list:                  0-11
+DEBUG util.py:461:  Vendor ID:                            ARM
+DEBUG util.py:461:  Model name:                           Neoverse-N1
+DEBUG util.py:461:  Model:                                1
+DEBUG util.py:461:  Thread(s) per core:                   1
+DEBUG util.py:461:  Core(s) per socket:                   1
+DEBUG util.py:461:  Socket(s):                            12
+DEBUG util.py:461:  Stepping:                             r3p1
+DEBUG util.py:461:  BogoMIPS:                             50.00
+DEBUG util.py:461:  Flags:                                fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp
+DEBUG util.py:461:  NUMA node(s):                         1
+DEBUG util.py:461:  NUMA node0 CPU(s):                    0-11
+DEBUG util.py:461:  Vulnerability Gather data sampling:   Not affected
+DEBUG util.py:461:  Vulnerability Itlb multihit:          Not affected
+DEBUG util.py:461:  Vulnerability L1tf:                   Not affected
+DEBUG util.py:461:  Vulnerability Mds:                    Not affected
+DEBUG util.py:461:  Vulnerability Meltdown:               Not affected
+DEBUG util.py:461:  Vulnerability Mmio stale data:        Not affected
+DEBUG util.py:461:  Vulnerability Reg file data sampling: Not affected
+DEBUG util.py:461:  Vulnerability Retbleed:               Not affected
+DEBUG util.py:461:  Vulnerability Spec rstack overflow:   Not affected
+DEBUG util.py:461:  Vulnerability Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl
+DEBUG util.py:461:  Vulnerability Spectre v1:             Mitigation; __user pointer sanitization
+DEBUG util.py:461:  Vulnerability Spectre v2:             Mitigation; CSV2, BHB
+DEBUG util.py:461:  Vulnerability Srbds:                  Not affected
+DEBUG util.py:461:  Vulnerability Tsx async abort:        Not affected
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/free'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:461:                 total        used        free      shared  buff/cache   available
+DEBUG util.py:461:  Mem:        36854628     1235580    13543136         256    22494600    35619048
+DEBUG util.py:461:  Swap:        8388604       98548     8290056
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/df', '-H', '-T', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/cache/mock'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:461:  Filesystem     Type   Size  Used Avail Use% Mounted on
+DEBUG util.py:461:  /dev/vda3      btrfs  313G   28G  280G   9% /
+DEBUG util.py:461:  /dev/vda3      btrfs  313G   28G  280G   9% /
+DEBUG util.py:608:  Child return code was: 0
+DEBUG buildroot.py:721:  create skeleton dirs
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/rpm
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/yum
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/dbus
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/dbus
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/log
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/log
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/cache/dnf
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/cache/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/cache/yum
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/cache/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/rpm
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/tmp
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/tmp/ccache
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/tmp/ccache
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/tmp
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf/vars
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf/vars
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum.repos.d
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum.repos.d
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/mapper
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/mapper
+DEBUG buildroot.py:865:  kernel version == 6.12.10-200.fc41.aarch64
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/fstab
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum/yum.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf/dnf.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/log/yum.log
+DEBUG buildroot.py:330:  rootdir = /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG buildroot.py:331:  resultdir = /var/lib/mock/eln-build-side-108102-58033177-6561774/result
+INFO buildroot.py:179:  Package manager dnf5 detected and used (direct choice)
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/mock
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/mock
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust with files from /etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/./extracted
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/./extracted
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/./source
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/./source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/edk2
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/edk2
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/java
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/java
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/openssl
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/openssl
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/pem
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/pem
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/pem/directory-hash
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/pem/directory-hash
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/source/anchors
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/source/anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/source/blocklist
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/source/blocklist
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source with files from /usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source/./anchors
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source/./anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source/./blocklist
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source/./blocklist
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf
+DEBUG package_manager.py:689:  configure DNF vars
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/proc', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/sys', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'devpts', '-o', 'gid=5,mode=0620,ptmxmode=0666,newinstance', 'devpts', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'bind', '/tmp/mock-selinux-plugin.ym273k4g', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'private,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,private,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir
+DEBUG package_manager.py:295:  ['/usr/bin/dnf5', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/', 'install', '@build', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing']
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.7zqdht6u:/etc/resolv.conf']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', 'e844de33598a4146a1acc89b2b74910e', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.7zqdht6u:/etc/resolv.conf', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--setenv=LC_MESSAGES=C.UTF-8', '--resolv-conf=off', '/usr/bin/dnf5', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/', 'install', '@build', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing', '--setopt=tsflags=nocontexts'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'LC_MESSAGES': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:459:  Updating and loading repositories:
+DEBUG util.py:459:   build                                  100% | 117.5 MiB/s |  14.5 MiB |  00m00s
+DEBUG util.py:459:  Repositories loaded.
+DEBUG util.py:459:  No match for group package: fedora-release
+DEBUG util.py:461:  Package                      Arch    Version                      Repository      Size
+DEBUG util.py:461:  Installing group/module packages:
+DEBUG util.py:461:   bash                        aarch64 5.2.37-3.eln146              build        8.2 MiB
+DEBUG util.py:461:   bzip2                       aarch64 1.0.8-20.eln145              build      171.3 KiB
+DEBUG util.py:461:   coreutils                   aarch64 9.6-2.eln146                 build        8.1 MiB
+DEBUG util.py:461:   cpio                        aarch64 2.15-4.eln146                build        1.1 MiB
+DEBUG util.py:461:   diffutils                   aarch64 3.10-9.eln145                build        1.6 MiB
+DEBUG util.py:461:   findutils                   aarch64 1:4.10.0-5.eln145            build        1.9 MiB
+DEBUG util.py:461:   gawk                        aarch64 5.3.1-1.eln145               build        2.4 MiB
+DEBUG util.py:461:   glibc-minimal-langpack      aarch64 2.41.9000-2.eln146           build        0.0   B
+DEBUG util.py:461:   grep                        aarch64 3.11-10.eln145               build        1.0 MiB
+DEBUG util.py:461:   gzip                        aarch64 1.13-3.eln145                build      424.7 KiB
+DEBUG util.py:461:   info                        aarch64 7.2-3.eln145                 build      421.6 KiB
+DEBUG util.py:461:   patch                       aarch64 2.7.6-26.eln145              build      262.4 KiB
+DEBUG util.py:461:   redhat-rpm-config           noarch  342-2.eln145                 build      186.8 KiB
+DEBUG util.py:461:   rpm-build                   aarch64 4.20.1-1.eln146              build      524.5 KiB
+DEBUG util.py:461:   sed                         aarch64 4.9-4.eln145                 build      873.2 KiB
+DEBUG util.py:461:   shadow-utils                aarch64 2:4.17.0-4.eln145            build        4.5 MiB
+DEBUG util.py:461:   tar                         aarch64 2:1.35-5.eln145              build        3.0 MiB
+DEBUG util.py:461:   unzip                       aarch64 6.0-66.eln145                build      470.2 KiB
+DEBUG util.py:461:   util-linux                  aarch64 2.40.4-7.eln146              build        6.6 MiB
+DEBUG util.py:461:   which                       aarch64 2.23-1.eln145                build      123.4 KiB
+DEBUG util.py:461:   xz                          aarch64 1:5.6.3-3.eln145             build        1.3 MiB
+DEBUG util.py:461:  Installing dependencies:
+DEBUG util.py:461:   alternatives                aarch64 1.32-1.eln146                build       90.2 KiB
+DEBUG util.py:461:   audit-libs                  aarch64 4.0.3-2.eln145               build      419.2 KiB
+DEBUG util.py:461:   binutils                    aarch64 2.44-3.eln146                build       29.3 MiB
+DEBUG util.py:461:   bzip2-libs                  aarch64 1.0.8-20.eln145              build       72.6 KiB
+DEBUG util.py:461:   ca-certificates             noarch  2024.2.69_v8.0.401-5.eln145  build        2.6 MiB
+DEBUG util.py:461:   coreutils-common            aarch64 9.6-2.eln146                 build       11.1 MiB
+DEBUG util.py:461:   crypto-policies             noarch  20250214-1.gitfd9b9b9.eln146 build      109.2 KiB
+DEBUG util.py:461:   curl                        aarch64 8.13.0~rc1-2.eln146          build      457.0 KiB
+DEBUG util.py:461:   cyrus-sasl-lib              aarch64 2.1.28-30.eln145             build      907.7 KiB
+DEBUG util.py:461:   debugedit                   aarch64 5.1-5.eln146                 build      244.6 KiB
+DEBUG util.py:461:   dwz                         aarch64 0.15-9.eln145                build      322.6 KiB
+DEBUG util.py:461:   ed                          aarch64 1.21-2.eln145                build      154.5 KiB
+DEBUG util.py:461:   efi-srpm-macros             noarch  6-3.eln146                   build       40.1 KiB
+DEBUG util.py:461:   elfutils                    aarch64 0.192-8.eln145               build        3.1 MiB
+DEBUG util.py:461:   elfutils-debuginfod-client  aarch64 0.192-8.eln145               build      143.9 KiB
+DEBUG util.py:461:   elfutils-default-yama-scope noarch  0.192-8.eln145               build        1.8 KiB
+DEBUG util.py:461:   elfutils-libelf             aarch64 0.192-8.eln145               build        1.2 MiB
+DEBUG util.py:461:   elfutils-libs               aarch64 0.192-8.eln145               build      746.4 KiB
+DEBUG util.py:461:   fedora-gpg-keys             noarch  43-0.1.eln146                build      128.2 KiB
+DEBUG util.py:461:   fedora-release-common       noarch  43-0.7.eln147                build       20.4 KiB
+DEBUG util.py:461:   fedora-release-eln          noarch  43-0.7.eln147                build        0.0   B
+DEBUG util.py:461:   fedora-release-identity-eln noarch  43-0.7.eln147                build        1.7 KiB
+DEBUG util.py:461:   fedora-repos-eln            noarch  43-0.1.eln146                build       10.9 KiB
+DEBUG util.py:461:   file                        aarch64 5.46-1.eln145                build      140.2 KiB
+DEBUG util.py:461:   file-libs                   aarch64 5.46-1.eln145                build       11.9 MiB
+DEBUG util.py:461:   filesystem                  aarch64 3.18-38.eln146               build      112.0   B
+DEBUG util.py:461:   filesystem-srpm-macros      noarch  3.18-38.eln146               build       38.2 KiB
+DEBUG util.py:461:   fonts-srpm-macros           noarch  1:2.0.5-21.eln145            build       55.8 KiB
+DEBUG util.py:461:   forge-srpm-macros           noarch  0.4.0-2.eln145               build       38.9 KiB
+DEBUG util.py:461:   gdb-minimal                 aarch64 16.2-1.eln146                build       12.9 MiB
+DEBUG util.py:461:   gdbm-libs                   aarch64 1:1.23-9.eln145              build      234.0 KiB
+DEBUG util.py:461:   glibc                       aarch64 2.41.9000-2.eln146           build        6.3 MiB
+DEBUG util.py:461:   glibc-common                aarch64 2.41.9000-2.eln146           build        1.3 MiB
+DEBUG util.py:461:   glibc-gconv-extra           aarch64 2.41.9000-2.eln146           build       18.6 MiB
+DEBUG util.py:461:   gmp                         aarch64 1:6.3.0-3.eln146             build      657.9 KiB
+DEBUG util.py:461:   go-srpm-macros              noarch  3.6.0-1.eln144               build       60.6 KiB
+DEBUG util.py:461:   jansson                     aarch64 2.14-2.eln145                build       93.2 KiB
+DEBUG util.py:461:   json-c                      aarch64 0.18-2.eln145                build      138.7 KiB
+DEBUG util.py:461:   kernel-srpm-macros          noarch  1.0-25.eln145                build        1.9 KiB
+DEBUG util.py:461:   keyutils-libs               aarch64 1.6.3-5.eln145               build       98.3 KiB
+DEBUG util.py:461:   krb5-libs                   aarch64 1.21.3-5.eln145              build        2.5 MiB
+DEBUG util.py:461:   libacl                      aarch64 2.3.2-3.eln145               build       67.9 KiB
+DEBUG util.py:461:   libarchive                  aarch64 3.7.7-4.eln146               build      910.6 KiB
+DEBUG util.py:461:   libattr                     aarch64 2.5.2-5.eln145               build       68.5 KiB
+DEBUG util.py:461:   libblkid                    aarch64 2.40.4-7.eln146              build      290.5 KiB
+DEBUG util.py:461:   libbrotli                   aarch64 1.1.0-6.eln145               build      909.5 KiB
+DEBUG util.py:461:   libcap                      aarch64 2.73-2.eln145                build      506.8 KiB
+DEBUG util.py:461:   libcap-ng                   aarch64 0.8.5-4.eln145               build      161.0 KiB
+DEBUG util.py:461:   libcom_err                  aarch64 1.47.2-3.eln145              build      111.2 KiB
+DEBUG util.py:461:   libcurl                     aarch64 8.13.0~rc1-2.eln146          build      858.5 KiB
+DEBUG util.py:461:   libeconf                    aarch64 0.7.6-1.eln146               build       80.6 KiB
+DEBUG util.py:461:   libevent                    aarch64 2.1.12-15.eln145             build        1.1 MiB
+DEBUG util.py:461:   libfdisk                    aarch64 2.40.4-7.eln146              build      418.8 KiB
+DEBUG util.py:461:   libffi                      aarch64 3.4.7-2.eln146               build      154.7 KiB
+DEBUG util.py:461:   libgcc                      aarch64 15.0.1-0.10.eln146           build      222.2 KiB
+DEBUG util.py:461:   libgomp                     aarch64 15.0.1-0.10.eln146           build      511.4 KiB
+DEBUG util.py:461:   libidn2                     aarch64 2.3.8-1.eln146               build      560.6 KiB
+DEBUG util.py:461:   libmount                    aarch64 2.40.4-7.eln146              build      355.8 KiB
+DEBUG util.py:461:   libnghttp2                  aarch64 1.65.0-1.eln146              build      197.9 KiB
+DEBUG util.py:461:   libpkgconf                  aarch64 2.3.0-2.eln145               build      134.0 KiB
+DEBUG util.py:461:   libpsl                      aarch64 0.21.5-5.eln145              build      132.5 KiB
+DEBUG util.py:461:   libselinux                  aarch64 3.8-1.eln145                 build      201.1 KiB
+DEBUG util.py:461:   libsemanage                 aarch64 3.8-1.eln145                 build      360.1 KiB
+DEBUG util.py:461:   libsepol                    aarch64 3.8-1.eln145                 build      810.0 KiB
+DEBUG util.py:461:   libsmartcols                aarch64 2.40.4-7.eln146              build      224.4 KiB
+DEBUG util.py:461:   libssh                      aarch64 0.11.1-4.eln145              build      585.4 KiB
+DEBUG util.py:461:   libssh-config               noarch  0.11.1-4.eln145              build      277.0   B
+DEBUG util.py:461:   libstdc++                   aarch64 15.0.1-0.10.eln146           build        2.9 MiB
+DEBUG util.py:461:   libtasn1                    aarch64 4.20.0-1.eln146              build      220.4 KiB
+DEBUG util.py:461:   libtool-ltdl                aarch64 2.5.4-4.eln145               build       94.0 KiB
+DEBUG util.py:461:   libunistring                aarch64 1.1-9.eln145                 build        1.7 MiB
+DEBUG util.py:461:   libuuid                     aarch64 2.40.4-7.eln146              build       69.4 KiB
+DEBUG util.py:461:   libverto                    aarch64 0.3.2-10.eln145              build       69.4 KiB
+DEBUG util.py:461:   libxcrypt                   aarch64 4.4.38-6.eln146              build      272.1 KiB
+DEBUG util.py:461:   libxml2                     aarch64 2.12.10-1.eln146             build        1.9 MiB
+DEBUG util.py:461:   libzstd                     aarch64 1.5.7-1.eln146               build      667.7 KiB
+DEBUG util.py:461:   lua-libs                    aarch64 5.4.7-3.eln146               build      328.9 KiB
+DEBUG util.py:461:   lua-srpm-macros             noarch  1-15.eln145                  build        1.3 KiB
+DEBUG util.py:461:   lz4-libs                    aarch64 1.10.0-2.eln145              build      197.4 KiB
+DEBUG util.py:461:   mpfr                        aarch64 4.2.1-6.eln145               build      754.7 KiB
+DEBUG util.py:461:   ncurses-base                noarch  6.5-5.20250125.eln145        build      326.8 KiB
+DEBUG util.py:461:   ncurses-libs                aarch64 6.5-5.20250125.eln145        build        1.2 MiB
+DEBUG util.py:461:   ocaml-srpm-macros           noarch  10-4.eln145                  build        1.9 KiB
+DEBUG util.py:461:   openblas-srpm-macros        noarch  2-19.eln145                  build      112.0   B
+DEBUG util.py:461:   openldap                    aarch64 2.6.9-3.eln145               build      697.3 KiB
+DEBUG util.py:461:   openssl-libs                aarch64 1:3.2.4-3.eln146             build        6.3 MiB
+DEBUG util.py:461:   p11-kit                     aarch64 0.25.5-5.eln145              build        2.4 MiB
+DEBUG util.py:461:   p11-kit-trust               aarch64 0.25.5-5.eln145              build      463.3 KiB
+DEBUG util.py:461:   package-notes-srpm-macros   noarch  0.5-13.eln145                build        1.6 KiB
+DEBUG util.py:461:   pam-libs                    aarch64 1.7.0-4.eln145               build      222.9 KiB
+DEBUG util.py:461:   pcre2                       aarch64 10.45-1.eln146               build      713.6 KiB
+DEBUG util.py:461:   pcre2-syntax                noarch  10.45-1.eln146               build      273.9 KiB
+DEBUG util.py:461:   perl-srpm-macros            noarch  1-57.eln145                  build      861.0   B
+DEBUG util.py:461:   pkgconf                     aarch64 2.3.0-2.eln145               build      112.5 KiB
+DEBUG util.py:461:   pkgconf-m4                  noarch  2.3.0-2.eln145               build       14.4 KiB
+DEBUG util.py:461:   pkgconf-pkg-config          aarch64 2.3.0-2.eln145               build      990.0   B
+DEBUG util.py:461:   popt                        aarch64 1.19-8.eln145                build      144.8 KiB
+DEBUG util.py:461:   publicsuffix-list-dafsa     noarch  20250116-1.eln145            build       68.5 KiB
+DEBUG util.py:461:   pyproject-srpm-macros       noarch  1.17.0-1.eln146              build        1.9 KiB
+DEBUG util.py:461:   python-srpm-macros          noarch  3.13-4.eln145                build       51.0 KiB
+DEBUG util.py:461:   qt6-srpm-macros             noarch  6.8.2-2.eln146               build      464.0   B
+DEBUG util.py:461:   readline                    aarch64 8.2-13.eln146                build      561.1 KiB
+DEBUG util.py:461:   rpm                         aarch64 4.20.1-1.eln146              build        3.3 MiB
+DEBUG util.py:461:   rpm-build-libs              aarch64 4.20.1-1.eln146              build      198.6 KiB
+DEBUG util.py:461:   rpm-libs                    aarch64 4.20.1-1.eln146              build      733.6 KiB
+DEBUG util.py:461:   rpm-sequoia                 aarch64 1.7.0-2.eln146               build        2.3 MiB
+DEBUG util.py:461:   rust-toolset-srpm-macros    noarch  1.85.0-5.eln146              build        2.0 KiB
+DEBUG util.py:461:   setup                       noarch  2.15.0-14.eln146             build      720.9 KiB
+DEBUG util.py:461:   sqlite-libs                 aarch64 3.49.0-1.eln146              build        1.5 MiB
+DEBUG util.py:461:   systemd-libs                aarch64 257.4-1.eln146               build        2.3 MiB
+DEBUG util.py:461:   systemd-standalone-sysusers aarch64 257.4-1.eln146               build      329.4 KiB
+DEBUG util.py:461:   util-linux-core             aarch64 2.40.4-7.eln146              build        2.4 MiB
+DEBUG util.py:461:   xz-libs                     aarch64 1:5.6.3-3.eln145             build      202.3 KiB
+DEBUG util.py:461:   zip                         aarch64 3.0-43.eln145                build      762.5 KiB
+DEBUG util.py:461:   zlib-ng-compat              aarch64 2.2.4-2.eln146               build      133.4 KiB
+DEBUG util.py:461:   zstd                        aarch64 1.5.7-1.eln146               build        1.5 MiB
+DEBUG util.py:461:  Installing groups:
+DEBUG util.py:461:   build                                                                                
+DEBUG util.py:461:  Transaction Summary:
+DEBUG util.py:461:   Installing:       137 packages
+DEBUG util.py:459:  Total size of inbound packages is 49 MiB. Need to download 49 MiB.
+DEBUG util.py:459:  After this operation, 198 MiB extra will be used (install 198 MiB, remove 0 B).
+DEBUG util.py:459:  [  1/137] bzip2-0:1.0.8-20.eln145.aarch 100% |   2.1 MiB/s |  51.9 KiB |  00m00s
+DEBUG util.py:459:  [  2/137] cpio-0:2.15-4.eln146.aarch64  100% |  25.3 MiB/s | 284.6 KiB |  00m00s
+DEBUG util.py:459:  [  3/137] bash-0:5.2.37-3.eln146.aarch6 100% |  42.0 MiB/s |   1.8 MiB |  00m00s
+DEBUG util.py:459:  [  4/137] coreutils-0:9.6-2.eln146.aarc 100% |  22.9 MiB/s |   1.1 MiB |  00m00s
+DEBUG util.py:459:  [  5/137] diffutils-0:3.10-9.eln145.aar 100% |  29.5 MiB/s | 393.2 KiB |  00m00s
+DEBUG util.py:459:  [  6/137] findutils-1:4.10.0-5.eln145.a 100% |  48.4 MiB/s | 545.7 KiB |  00m00s
+DEBUG util.py:459:  [  7/137] glibc-minimal-langpack-0:2.41 100% |  20.8 MiB/s | 127.8 KiB |  00m00s
+DEBUG util.py:459:  [  8/137] grep-0:3.11-10.eln145.aarch64 100% |  46.6 MiB/s | 286.5 KiB |  00m00s
+DEBUG util.py:459:  [  9/137] gzip-0:1.13-3.eln145.aarch64  100% |  26.4 MiB/s | 162.0 KiB |  00m00s
+DEBUG util.py:459:  [ 10/137] gawk-0:5.3.1-1.eln145.aarch64 100% |  49.7 MiB/s |   1.0 MiB |  00m00s
+DEBUG util.py:459:  [ 11/137] patch-0:2.7.6-26.eln145.aarch 100% |  24.5 MiB/s | 125.7 KiB |  00m00s
+DEBUG util.py:459:  [ 12/137] redhat-rpm-config-0:342-2.eln 100% |  14.6 MiB/s |  74.7 KiB |  00m00s
+DEBUG util.py:459:  [ 13/137] rpm-build-0:4.20.1-1.eln146.a 100% |  14.7 MiB/s |  75.1 KiB |  00m00s
+DEBUG util.py:459:  [ 14/137] info-0:7.2-3.eln145.aarch64   100% |  10.3 MiB/s | 179.6 KiB |  00m00s
+DEBUG util.py:459:  [ 15/137] sed-0:4.9-4.eln145.aarch64    100% |  49.8 MiB/s | 306.3 KiB |  00m00s
+DEBUG util.py:459:  [ 16/137] shadow-utils-2:4.17.0-4.eln14 100% |  83.3 MiB/s |   1.2 MiB |  00m00s
+DEBUG util.py:459:  [ 17/137] unzip-0:6.0-66.eln145.aarch64 100% |  16.2 MiB/s | 182.9 KiB |  00m00s
+DEBUG util.py:459:  [ 18/137] tar-2:1.35-5.eln145.aarch64   100% |  48.5 MiB/s | 844.4 KiB |  00m00s
+DEBUG util.py:459:  [ 19/137] which-0:2.23-1.eln145.aarch64 100% |  10.1 MiB/s |  41.3 KiB |  00m00s
+DEBUG util.py:459:  [ 20/137] xz-1:5.6.3-3.eln145.aarch64   100% |  45.0 MiB/s | 461.2 KiB |  00m00s
+DEBUG util.py:459:  [ 21/137] util-linux-0:2.40.4-7.eln146. 100% |  60.9 MiB/s |   1.1 MiB |  00m00s
+DEBUG util.py:459:  [ 22/137] ncurses-libs-0:6.5-5.20250125 100% |  52.8 MiB/s | 324.5 KiB |  00m00s
+DEBUG util.py:459:  [ 23/137] filesystem-0:3.18-38.eln146.a 100% |  48.7 MiB/s |   1.3 MiB |  00m00s
+DEBUG util.py:459:  [ 24/137] bzip2-libs-0:1.0.8-20.eln145. 100% |   5.0 MiB/s |  41.2 KiB |  00m00s
+DEBUG util.py:459:  [ 25/137] glibc-0:2.41.9000-2.eln146.aa 100% |  62.8 MiB/s |   1.9 MiB |  00m00s
+DEBUG util.py:459:  [ 26/137] gmp-1:6.3.0-3.eln146.aarch64  100% |  20.5 MiB/s | 272.5 KiB |  00m00s
+DEBUG util.py:459:  [ 27/137] libacl-0:2.3.2-3.eln145.aarch 100% |   4.8 MiB/s |  24.4 KiB |  00m00s
+DEBUG util.py:459:  [ 28/137] libattr-0:2.5.2-5.eln145.aarc 100% |   5.8 MiB/s |  17.8 KiB |  00m00s
+DEBUG util.py:459:  [ 29/137] libcap-0:2.73-2.eln145.aarch6 100% |  20.8 MiB/s |  85.4 KiB |  00m00s
+DEBUG util.py:459:  [ 30/137] libselinux-0:3.8-1.eln145.aar 100% |  31.2 MiB/s |  95.9 KiB |  00m00s
+DEBUG util.py:459:  [ 31/137] coreutils-common-0:9.6-2.eln1 100% |  62.4 MiB/s |   2.1 MiB |  00m00s
+DEBUG util.py:459:  [ 32/137] systemd-libs-0:257.4-1.eln146 100% |  44.6 MiB/s | 777.1 KiB |  00m00s
+DEBUG util.py:459:  [ 33/137] mpfr-0:4.2.1-6.eln145.aarch64 100% |  28.6 MiB/s | 322.0 KiB |  00m00s
+DEBUG util.py:459:  [ 34/137] readline-0:8.2-13.eln146.aarc 100% |  34.4 MiB/s | 211.6 KiB |  00m00s
+DEBUG util.py:459:  [ 35/137] openssl-libs-1:3.2.4-3.eln146 100% |  66.0 MiB/s |   2.2 MiB |  00m00s
+DEBUG util.py:459:  [ 36/137] glibc-common-0:2.41.9000-2.el 100% |  27.7 MiB/s | 397.6 KiB |  00m00s
+DEBUG util.py:459:  [ 37/137] pcre2-0:10.45-1.eln146.aarch6 100% |  19.8 MiB/s | 242.7 KiB |  00m00s
+DEBUG util.py:459:  [ 38/137] ed-0:1.21-2.eln145.aarch64    100% |  11.4 MiB/s |  82.0 KiB |  00m00s
+DEBUG util.py:459:  [ 39/137] dwz-0:0.15-9.eln145.aarch64   100% |  25.7 MiB/s | 131.8 KiB |  00m00s
+DEBUG util.py:459:  [ 40/137] efi-srpm-macros-0:6-3.eln146. 100% |   5.5 MiB/s |  22.6 KiB |  00m00s
+DEBUG util.py:459:  [ 41/137] file-0:5.46-1.eln145.aarch64  100% |  12.0 MiB/s |  49.0 KiB |  00m00s
+DEBUG util.py:459:  [ 42/137] filesystem-srpm-macros-0:3.18 100% |   6.2 MiB/s |  25.6 KiB |  00m00s
+DEBUG util.py:459:  [ 43/137] forge-srpm-macros-0:0.4.0-2.e 100% |   4.9 MiB/s |  19.9 KiB |  00m00s
+DEBUG util.py:459:  [ 44/137] fonts-srpm-macros-1:2.0.5-21. 100% |   3.8 MiB/s |  27.1 KiB |  00m00s
+DEBUG util.py:459:  [ 45/137] go-srpm-macros-0:3.6.0-1.eln1 100% |   5.3 MiB/s |  27.0 KiB |  00m00s
+DEBUG util.py:459:  [ 46/137] kernel-srpm-macros-0:1.0-25.e 100% |   1.9 MiB/s |   9.9 KiB |  00m00s
+DEBUG util.py:459:  [ 47/137] lua-srpm-macros-0:1-15.eln145 100% |   1.2 MiB/s |   8.9 KiB |  00m00s
+DEBUG util.py:459:  [ 48/137] ocaml-srpm-macros-0:10-4.eln1 100% |   1.5 MiB/s |   9.2 KiB |  00m00s
+DEBUG util.py:459:  [ 49/137] openblas-srpm-macros-0:2-19.e 100% |   1.9 MiB/s |   7.8 KiB |  00m00s
+DEBUG util.py:459:  [ 50/137] perl-srpm-macros-0:1-57.eln14 100% |   2.1 MiB/s |   8.5 KiB |  00m00s
+DEBUG util.py:459:  [ 51/137] package-notes-srpm-macros-0:0 100% |   1.5 MiB/s |   9.3 KiB |  00m00s
+DEBUG util.py:459:  [ 52/137] pyproject-srpm-macros-0:1.17. 100% |   2.7 MiB/s |  13.9 KiB |  00m00s
+DEBUG util.py:459:  [ 53/137] python-srpm-macros-0:3.13-4.e 100% |   5.6 MiB/s |  23.1 KiB |  00m00s
+DEBUG util.py:459:  [ 54/137] qt6-srpm-macros-0:6.8.2-2.eln 100% |   1.8 MiB/s |   9.4 KiB |  00m00s
+DEBUG util.py:459:  [ 55/137] rpm-0:4.20.1-1.eln146.aarch64 100% |  72.2 MiB/s | 517.7 KiB |  00m00s
+DEBUG util.py:459:  [ 56/137] rust-toolset-srpm-macros-0:1. 100% |   2.0 MiB/s |  14.6 KiB |  00m00s
+DEBUG util.py:459:  [ 57/137] zip-0:3.0-43.eln145.aarch64   100% |  36.4 MiB/s | 261.1 KiB |  00m00s
+DEBUG util.py:459:  [ 58/137] debugedit-0:5.1-5.eln146.aarc 100% |  19.1 MiB/s |  78.1 KiB |  00m00s
+DEBUG util.py:459:  [ 59/137] elfutils-libelf-0:0.192-8.eln 100% |  50.6 MiB/s | 207.2 KiB |  00m00s
+DEBUG util.py:459:  [ 60/137] elfutils-0:0.192-8.eln145.aar 100% |  43.1 MiB/s | 530.1 KiB |  00m00s
+DEBUG util.py:459:  [ 61/137] libarchive-0:3.7.7-4.eln146.a 100% |  44.0 MiB/s | 405.7 KiB |  00m00s
+DEBUG util.py:459:  [ 62/137] pkgconf-pkg-config-0:2.3.0-2. 100% |   1.6 MiB/s |   9.9 KiB |  00m00s
+DEBUG util.py:459:  [ 63/137] popt-0:1.19-8.eln145.aarch64  100% |  19.2 MiB/s |  58.9 KiB |  00m00s
+DEBUG util.py:459:  [ 64/137] rpm-build-libs-0:4.20.1-1.eln 100% |  23.0 MiB/s |  94.3 KiB |  00m00s
+DEBUG util.py:459:  [ 65/137] rpm-libs-0:4.20.1-1.eln146.aa 100% |  59.7 MiB/s | 305.5 KiB |  00m00s
+DEBUG util.py:459:  [ 66/137] zstd-0:1.5.7-1.eln146.aarch64 100% |  48.4 MiB/s | 445.9 KiB |  00m00s
+DEBUG util.py:459:  [ 67/137] audit-libs-0:4.0.3-2.eln145.a 100% |  21.2 MiB/s | 130.0 KiB |  00m00s
+DEBUG util.py:459:  [ 68/137] libeconf-0:0.7.6-1.eln146.aar 100% |  11.5 MiB/s |  35.3 KiB |  00m00s
+DEBUG util.py:459:  [ 69/137] libsemanage-0:3.8-1.eln145.aa 100% |  23.2 MiB/s | 118.8 KiB |  00m00s
+DEBUG util.py:459:  [ 70/137] libxcrypt-0:4.4.38-6.eln146.a 100% |  30.3 MiB/s | 124.2 KiB |  00m00s
+DEBUG util.py:459:  [ 71/137] pam-libs-0:1.7.0-4.eln145.aar 100% |  14.2 MiB/s |  58.1 KiB |  00m00s
+DEBUG util.py:459:  [ 72/137] setup-0:2.15.0-14.eln146.noar 100% |  36.6 MiB/s | 149.7 KiB |  00m00s
+DEBUG util.py:459:  [ 73/137] libblkid-0:2.40.4-7.eln146.aa 100% |  29.4 MiB/s | 120.5 KiB |  00m00s
+DEBUG util.py:459:  [ 74/137] libcap-ng-0:0.8.5-4.eln145.aa 100% |  10.5 MiB/s |  32.3 KiB |  00m00s
+DEBUG util.py:459:  [ 75/137] libmount-0:2.40.4-7.eln146.aa 100% |  36.6 MiB/s | 149.8 KiB |  00m00s
+DEBUG util.py:459:  [ 76/137] libfdisk-0:2.40.4-7.eln146.aa 100% |  21.1 MiB/s | 151.3 KiB |  00m00s
+DEBUG util.py:459:  [ 77/137] libuuid-0:2.40.4-7.eln146.aar 100% |   8.2 MiB/s |  25.3 KiB |  00m00s
+DEBUG util.py:459:  [ 78/137] libsmartcols-0:2.40.4-7.eln14 100% |  19.4 MiB/s |  79.4 KiB |  00m00s
+DEBUG util.py:459:  [ 79/137] binutils-0:2.44-3.eln146.aarc 100% |  77.7 MiB/s |   6.1 MiB |  00m00s
+DEBUG util.py:459:  [ 80/137] zlib-ng-compat-0:2.2.4-2.eln1 100% |   5.4 MiB/s |  65.9 KiB |  00m00s
+DEBUG util.py:459:  [ 81/137] xz-libs-1:5.6.3-3.eln145.aarc 100% |  27.1 MiB/s | 111.0 KiB |  00m00s
+DEBUG util.py:459:  [ 82/137] util-linux-core-0:2.40.4-7.el 100% |  27.3 MiB/s | 504.0 KiB |  00m00s
+DEBUG util.py:459:  [ 83/137] libgcc-0:15.0.1-0.10.eln146.a 100% |  25.4 MiB/s | 104.1 KiB |  00m00s
+DEBUG util.py:459:  [ 84/137] ncurses-base-0:6.5-5.20250125 100% |  20.7 MiB/s |  63.6 KiB |  00m00s
+DEBUG util.py:459:  [ 85/137] libsepol-0:3.8-1.eln145.aarch 100% |  63.3 MiB/s | 324.1 KiB |  00m00s
+DEBUG util.py:459:  [ 86/137] crypto-policies-0:20250214-1. 100% |  15.9 MiB/s |  65.0 KiB |  00m00s
+DEBUG util.py:459:  [ 87/137] pcre2-syntax-0:10.45-1.eln146 100% |  39.5 MiB/s | 161.8 KiB |  00m00s
+DEBUG util.py:459:  [ 88/137] ca-certificates-0:2024.2.69_v 100% |  57.7 MiB/s | 945.1 KiB |  00m00s
+DEBUG util.py:459:  [ 89/137] glibc-gconv-extra-0:2.41.9000 100% |  55.0 MiB/s |   1.7 MiB |  00m00s
+DEBUG util.py:459:  [ 90/137] alternatives-0:1.32-1.eln146. 100% |  19.9 MiB/s |  40.8 KiB |  00m00s
+DEBUG util.py:459:  [ 91/137] curl-0:8.13.0~rc1-2.eln146.aa 100% |  43.9 MiB/s | 224.5 KiB |  00m00s
+DEBUG util.py:459:  [ 92/137] file-libs-0:5.46-1.eln145.aar 100% |  48.7 MiB/s | 847.6 KiB |  00m00s
+DEBUG util.py:459:  [ 93/137] elfutils-debuginfod-client-0: 100% |   7.5 MiB/s |  46.0 KiB |  00m00s
+DEBUG util.py:459:  [ 94/137] jansson-0:2.14-2.eln145.aarch 100% |   9.1 MiB/s |  46.8 KiB |  00m00s
+DEBUG util.py:459:  [ 95/137] elfutils-libs-0:0.192-8.eln14 100% |  50.8 MiB/s | 260.1 KiB |  00m00s
+DEBUG util.py:459:  [ 96/137] libzstd-0:1.5.7-1.eln146.aarc 100% |  39.5 MiB/s | 283.1 KiB |  00m00s
+DEBUG util.py:459:  [ 97/137] libstdc++-0:15.0.1-0.10.eln14 100% |  63.9 MiB/s | 850.5 KiB |  00m00s
+DEBUG util.py:459:  [ 98/137] lz4-libs-0:1.10.0-2.eln145.aa 100% |  15.5 MiB/s |  79.6 KiB |  00m00s
+DEBUG util.py:459:  [ 99/137] pkgconf-0:2.3.0-2.eln145.aarc 100% |  10.9 MiB/s |  44.7 KiB |  00m00s
+DEBUG util.py:459:  [100/137] libxml2-0:2.12.10-1.eln146.aa 100% |  51.1 MiB/s | 679.7 KiB |  00m00s
+DEBUG util.py:459:  [101/137] pkgconf-m4-0:2.3.0-2.eln145.n 100% |   2.8 MiB/s |  14.3 KiB |  00m00s
+DEBUG util.py:459:  [102/137] lua-libs-0:5.4.7-3.eln146.aar 100% |  41.8 MiB/s | 128.4 KiB |  00m00s
+DEBUG util.py:459:  [103/137] libgomp-0:15.0.1-0.10.eln146. 100% |  48.3 MiB/s | 346.0 KiB |  00m00s
+DEBUG util.py:459:  [104/137] libffi-0:3.4.7-2.eln146.aarch 100% |  12.6 MiB/s |  38.6 KiB |  00m00s
+DEBUG util.py:459:  [105/137] rpm-sequoia-0:1.7.0-2.eln146. 100% |  61.1 MiB/s | 875.2 KiB |  00m00s
+DEBUG util.py:459:  [106/137] sqlite-libs-0:3.49.0-1.eln146 100% |  51.9 MiB/s | 744.1 KiB |  00m00s
+DEBUG util.py:459:  [107/137] p11-kit-trust-0:0.25.5-5.eln1 100% |  25.6 MiB/s | 131.2 KiB |  00m00s
+DEBUG util.py:459:  [108/137] json-c-0:0.18-2.eln145.aarch6 100% |  14.6 MiB/s |  44.9 KiB |  00m00s
+DEBUG util.py:459:  [109/137] p11-kit-0:0.25.5-5.eln145.aar 100% |  34.4 MiB/s | 458.5 KiB |  00m00s
+DEBUG util.py:459:  [110/137] elfutils-default-yama-scope-0 100% |   3.1 MiB/s |  12.7 KiB |  00m00s
+DEBUG util.py:459:  [111/137] libpkgconf-0:2.3.0-2.eln145.a 100% |   9.3 MiB/s |  38.2 KiB |  00m00s
+DEBUG util.py:459:  [112/137] libtasn1-0:4.20.0-1.eln146.aa 100% |  18.0 MiB/s |  73.7 KiB |  00m00s
+DEBUG util.py:459:  [113/137] fedora-release-eln-0:43-0.7.e 100% |   4.9 MiB/s |  15.0 KiB |  00m00s
+DEBUG util.py:459:  [114/137] fedora-release-common-0:43-0. 100% |   8.4 MiB/s |  25.9 KiB |  00m00s
+DEBUG util.py:459:  [115/137] fedora-repos-eln-0:43-0.1.eln 100% |   3.1 MiB/s |   9.4 KiB |  00m00s
+DEBUG util.py:459:  [116/137] fedora-release-identity-eln-0 100% |   4.2 MiB/s |  17.4 KiB |  00m00s
+DEBUG util.py:459:  [117/137] fedora-gpg-keys-0:43-0.1.eln1 100% |  30.6 MiB/s | 125.3 KiB |  00m00s
+DEBUG util.py:459:  [118/137] systemd-standalone-sysusers-0 100% |  49.2 MiB/s | 151.2 KiB |  00m00s
+DEBUG util.py:459:  [119/137] libcurl-0:8.13.0~rc1-2.eln146 100% |  73.7 MiB/s | 377.4 KiB |  00m00s
+DEBUG util.py:459:  [120/137] libbrotli-0:1.1.0-6.eln145.aa 100% |  47.5 MiB/s | 340.6 KiB |  00m00s
+DEBUG util.py:459:  [121/137] krb5-libs-0:1.21.3-5.eln145.a 100% |  52.4 MiB/s | 750.6 KiB |  00m00s
+DEBUG util.py:459:  [122/137] libnghttp2-0:1.65.0-1.eln146. 100% |  23.6 MiB/s |  72.5 KiB |  00m00s
+DEBUG util.py:459:  [123/137] libidn2-0:2.3.8-1.eln146.aarc 100% |  33.0 MiB/s | 168.8 KiB |  00m00s
+DEBUG util.py:459:  [124/137] libpsl-0:0.21.5-5.eln145.aarc 100% |  21.1 MiB/s |  64.9 KiB |  00m00s
+DEBUG util.py:459:  [125/137] libssh-0:0.11.1-4.eln145.aarc 100% |  45.0 MiB/s | 230.4 KiB |  00m00s
+DEBUG util.py:459:  [126/137] openldap-0:2.6.9-3.eln145.aar 100% |  41.0 MiB/s | 251.8 KiB |  00m00s
+DEBUG util.py:459:  [127/137] keyutils-libs-0:1.6.3-5.eln14 100% |   7.8 MiB/s |  31.7 KiB |  00m00s
+DEBUG util.py:459:  [128/137] libcom_err-0:1.47.2-3.eln145. 100% |  13.1 MiB/s |  26.8 KiB |  00m00s
+DEBUG util.py:459:  [129/137] libverto-0:0.3.2-10.eln145.aa 100% |   6.8 MiB/s |  20.8 KiB |  00m00s
+DEBUG util.py:459:  [130/137] publicsuffix-list-dafsa-0:202 100% |  14.4 MiB/s |  58.8 KiB |  00m00s
+DEBUG util.py:459:  [131/137] libunistring-0:1.1-9.eln145.a 100% |  40.5 MiB/s | 539.4 KiB |  00m00s
+DEBUG util.py:459:  [132/137] libssh-config-0:0.11.1-4.eln1 100% |   1.3 MiB/s |   9.1 KiB |  00m00s
+DEBUG util.py:459:  [133/137] gdb-minimal-0:16.2-1.eln146.a 100% |  66.2 MiB/s |   4.1 MiB |  00m00s
+DEBUG util.py:459:  [134/137] cyrus-sasl-lib-0:2.1.28-30.el 100% |   9.9 MiB/s | 101.6 KiB |  00m00s
+DEBUG util.py:459:  [135/137] libevent-0:2.1.12-15.eln145.a 100% |  19.1 MiB/s | 254.7 KiB |  00m00s
+DEBUG util.py:459:  [136/137] libtool-ltdl-0:2.5.4-4.eln145 100% |  17.3 MiB/s |  35.4 KiB |  00m00s
+DEBUG util.py:459:  [137/137] gdbm-libs-1:1.23-9.eln145.aar 100% |  13.7 MiB/s |  56.2 KiB |  00m00s
+DEBUG util.py:459:  --------------------------------------------------------------------------------
+DEBUG util.py:459:  [137/137] Total                         100% | 100.0 MiB/s |  49.0 MiB |  00m00s
+DEBUG util.py:459:  Running transaction
+DEBUG util.py:459:  [  1/139] Verify package files          100% | 713.0   B/s | 137.0   B |  00m00s
+DEBUG util.py:459:  [  2/139] Prepare transaction           100% |   2.1 KiB/s | 137.0   B |  00m00s
+DEBUG util.py:459:  [  3/139] Installing libgcc-0:15.0.1-0. 100% |  54.7 MiB/s | 223.9 KiB |  00m00s
+DEBUG util.py:459:  [  4/139] Installing libssh-config-0:0. 100% | 398.4 KiB/s | 816.0   B |  00m00s
+DEBUG util.py:459:  [  5/139] Installing publicsuffix-list- 100% |  33.8 MiB/s |  69.2 KiB |  00m00s
+DEBUG util.py:459:  [  6/139] Installing fedora-release-ide 100% | 829.4 KiB/s |   2.5 KiB |  00m00s
+DEBUG util.py:459:  [  7/139] Installing fedora-gpg-keys-0: 100% |   7.4 MiB/s | 174.8 KiB |  00m00s
+DEBUG util.py:459:  [  8/139] Installing fedora-release-com 100% |   4.8 MiB/s |  24.7 KiB |  00m00s
+DEBUG util.py:459:  [  9/139] Installing fedora-repos-eln-0 100% |   5.5 MiB/s |  11.2 KiB |  00m00s
+DEBUG util.py:459:  [ 10/139] Installing fedora-release-eln 100% |   2.5 KiB/s | 124.0   B |  00m00s
+DEBUG util.py:459:  >>> Running unknown scriptlet: setup-0:2.15.0-14.eln146.noarch                  
+DEBUG util.py:459:  >>> Finished unknown scriptlet: setup-0:2.15.0-14.eln146.noarch                 
+DEBUG util.py:459:  >>> Scriptlet output:                                                           
+DEBUG util.py:459:  >>> Creating group 'adm' with GID 4.                                            
+DEBUG util.py:459:  >>> Creating group 'audio' with GID 63.                                         
+DEBUG util.py:459:  >>> Creating group 'bin' with GID 1.                                            
+DEBUG util.py:459:  >>> Creating group 'cdrom' with GID 11.                                         
+DEBUG util.py:459:  >>> Creating group 'clock' with GID 103.                                        
+DEBUG util.py:459:  >>> Creating group 'daemon' with GID 2.                                         
+DEBUG util.py:459:  >>> Creating group 'dialout' with GID 18.                                       
+DEBUG util.py:459:  >>> Creating group 'disk' with GID 6.                                           
+DEBUG util.py:459:  >>> Creating group 'floppy' with GID 19.                                        
+DEBUG util.py:459:  >>> Creating group 'ftp' with GID 50.                                           
+DEBUG util.py:459:  >>> Creating group 'games' with GID 20.                                         
+DEBUG util.py:459:  >>> Creating group 'input' with GID 104.                                        
+DEBUG util.py:459:  >>> Creating group 'kmem' with GID 9.                                           
+DEBUG util.py:459:  >>> Creating group 'kvm' with GID 36.                                           
+DEBUG util.py:459:  >>> Creating group 'lock' with GID 54.                                          
+DEBUG util.py:459:  >>> Creating group 'lp' with GID 7.                                             
+DEBUG util.py:459:  >>> Creating group 'mail' with GID 12.                                          
+DEBUG util.py:459:  >>> Creating group 'man' with GID 15.                                           
+DEBUG util.py:459:  >>> Creating group 'mem' with GID 8.                                            
+DEBUG util.py:459:  >>> Creating group 'nobody' with GID 65534.                                     
+DEBUG util.py:459:  >>> Creating group 'render' with GID 105.                                       
+DEBUG util.py:459:  >>> Creating group 'root' with GID 0.                                           
+DEBUG util.py:459:  >>> Creating group 'sgx' with GID 106.                                          
+DEBUG util.py:459:  >>> Creating group 'sys' with GID 3.                                            
+DEBUG util.py:459:  >>> Creating group 'tape' with GID 33.                                          
+DEBUG util.py:459:  >>> Creating group 'tty' with GID 5.                                            
+DEBUG util.py:459:  >>> Creating group 'users' with GID 100.                                        
+DEBUG util.py:459:  >>> Creating group 'utmp' with GID 22.                                          
+DEBUG util.py:459:  >>> Creating group 'video' with GID 39.                                         
+DEBUG util.py:459:  >>> Creating group 'wheel' with GID 10.                                         
+DEBUG util.py:459:  >>>                                                                             
+DEBUG util.py:459:  >>> Running unknown scriptlet: setup-0:2.15.0-14.eln146.noarch                  
+DEBUG util.py:459:  >>> Finished unknown scriptlet: setup-0:2.15.0-14.eln146.noarch                 
+DEBUG util.py:459:  >>> Scriptlet output:                                                           
+DEBUG util.py:459:  >>> Creating user 'adm' (adm) with UID 3 and GID 4.                             
+DEBUG util.py:459:  >>> Creating user 'bin' (bin) with UID 1 and GID 1.                             
+DEBUG util.py:459:  >>> Creating user 'daemon' (daemon) with UID 2 and GID 2.                       
+DEBUG util.py:459:  >>> Creating user 'ftp' (FTP User) with UID 14 and GID 50.                      
+DEBUG util.py:459:  >>> Creating user 'games' (games) with UID 12 and GID 20.                       
+DEBUG util.py:459:  >>> Creating user 'halt' (halt) with UID 7 and GID 0.                           
+DEBUG util.py:459:  >>> Creating user 'lp' (lp) with UID 4 and GID 7.                               
+DEBUG util.py:459:  >>> Creating user 'mail' (mail) with UID 8 and GID 12.                          
+DEBUG util.py:459:  >>> Creating user 'nobody' (Kernel Overflow User) with UID 65534 and GID 65534. 
+DEBUG util.py:459:  >>> Creating user 'operator' (operator) with UID 11 and GID 0.                  
+DEBUG util.py:459:  >>> Creating user 'root' (Super User) with UID 0 and GID 0.                     
+DEBUG util.py:459:  >>> Creating user 'shutdown' (shutdown) with UID 6 and GID 0.                   
+DEBUG util.py:459:  >>> Creating user 'sync' (sync) with UID 5 and GID 0.                           
+DEBUG util.py:459:  >>>                                                                             
+DEBUG util.py:459:  [ 11/139] Installing setup-0:2.15.0-14. 100% |  28.4 MiB/s | 726.7 KiB |  00m00s
+DEBUG util.py:459:  >>> [RPM] /etc/hosts created as /etc/hosts.rpmnew                               
+DEBUG util.py:459:  [ 12/139] Installing filesystem-0:3.18- 100% |   1.2 MiB/s | 212.4 KiB |  00m00s
+DEBUG util.py:459:  [ 13/139] Installing pkgconf-m4-0:2.3.0 100% |   7.2 MiB/s |  14.8 KiB |  00m00s
+DEBUG util.py:459:  [ 14/139] Installing pcre2-syntax-0:10. 100% |  67.5 MiB/s | 276.4 KiB |  00m00s
+DEBUG util.py:459:  [ 15/139] Installing ncurses-base-0:6.5 100% |  20.2 MiB/s | 352.2 KiB |  00m00s
+DEBUG util.py:459:  [ 16/139] Installing glibc-minimal-lang 100% |  60.5 KiB/s | 124.0   B |  00m00s
+DEBUG util.py:459:  [ 17/139] Installing ncurses-libs-0:6.5 100% | 113.4 MiB/s |   1.2 MiB |  00m00s
+DEBUG util.py:459:  [ 18/139] Installing glibc-0:2.41.9000- 100% | 102.7 MiB/s |   6.3 MiB |  00m00s
+DEBUG util.py:459:  [ 19/139] Installing bash-0:5.2.37-3.el 100% | 132.0 MiB/s |   8.2 MiB |  00m00s
+DEBUG util.py:459:  [ 20/139] Installing glibc-common-0:2.4 100% |  45.7 MiB/s |   1.3 MiB |  00m00s
+DEBUG util.py:459:  [ 21/139] Installing glibc-gconv-extra- 100% | 188.5 MiB/s |  18.7 MiB |  00m00s
+DEBUG util.py:459:  [ 22/139] Installing zlib-ng-compat-0:2 100% |  43.7 MiB/s | 134.3 KiB |  00m00s
+DEBUG util.py:459:  [ 23/139] Installing bzip2-libs-0:1.0.8 100% |  24.0 MiB/s |  73.8 KiB |  00m00s
+DEBUG util.py:459:  [ 24/139] Installing xz-libs-1:5.6.3-3. 100% |  66.2 MiB/s | 203.4 KiB |  00m00s
+DEBUG util.py:459:  [ 25/139] Installing libuuid-0:2.40.4-7 100% |  34.4 MiB/s |  70.4 KiB |  00m00s
+DEBUG util.py:459:  [ 26/139] Installing libblkid-0:2.40.4- 100% |  47.5 MiB/s | 291.6 KiB |  00m00s
+DEBUG util.py:459:  [ 27/139] Installing gmp-1:6.3.0-3.eln1 100% | 107.4 MiB/s | 660.1 KiB |  00m00s
+DEBUG util.py:459:  [ 28/139] Installing readline-0:8.2-13. 100% |  91.7 MiB/s | 563.2 KiB |  00m00s
+DEBUG util.py:459:  [ 29/139] Installing popt-0:1.19-8.eln1 100% |  16.4 MiB/s | 151.4 KiB |  00m00s
+DEBUG util.py:459:  [ 30/139] Installing libxcrypt-0:4.4.38 100% |  53.7 MiB/s | 274.8 KiB |  00m00s
+DEBUG util.py:459:  [ 31/139] Installing libstdc++-0:15.0.1 100% | 181.3 MiB/s |   2.9 MiB |  00m00s
+DEBUG util.py:459:  [ 32/139] Installing libzstd-0:1.5.7-1. 100% | 130.7 MiB/s | 669.0 KiB |  00m00s
+DEBUG util.py:459:  [ 33/139] Installing elfutils-libelf-0: 100% | 169.9 MiB/s |   1.2 MiB |  00m00s
+DEBUG util.py:459:  [ 34/139] Installing libattr-0:2.5.2-5. 100% |  22.6 MiB/s |  69.4 KiB |  00m00s
+DEBUG util.py:459:  [ 35/139] Installing libacl-0:2.3.2-3.e 100% |  33.6 MiB/s |  68.8 KiB |  00m00s
+DEBUG util.py:459:  [ 36/139] Installing dwz-0:0.15-9.eln14 100% |  15.1 MiB/s | 324.0 KiB |  00m00s
+DEBUG util.py:459:  [ 37/139] Installing mpfr-0:4.2.1-6.eln 100% | 123.1 MiB/s | 756.3 KiB |  00m00s
+DEBUG util.py:459:  [ 38/139] Installing gawk-0:5.3.1-1.eln 100% |  68.1 MiB/s |   2.5 MiB |  00m00s
+DEBUG util.py:459:  [ 39/139] Installing unzip-0:6.0-66.eln 100% |  21.0 MiB/s | 473.7 KiB |  00m00s
+DEBUG util.py:459:  [ 40/139] Installing file-libs-0:5.46-1 100% | 360.0 MiB/s |  11.9 MiB |  00m00s
+DEBUG util.py:459:  [ 41/139] Installing file-0:5.46-1.eln1 100% |   4.0 MiB/s | 141.7 KiB |  00m00s
+DEBUG util.py:459:  [ 42/139] Installing crypto-policies-0: 100% |   7.6 MiB/s | 131.6 KiB |  00m00s
+DEBUG util.py:459:  [ 43/139] Installing pcre2-0:10.45-1.el 100% | 116.4 MiB/s | 715.0 KiB |  00m00s
+DEBUG util.py:459:  [ 44/139] Installing grep-0:3.11-10.eln 100% |  30.4 MiB/s |   1.0 MiB |  00m00s
+DEBUG util.py:459:  [ 45/139] Installing xz-1:5.6.3-3.eln14 100% |  37.8 MiB/s |   1.3 MiB |  00m00s
+DEBUG util.py:459:  [ 46/139] Installing libeconf-0:0.7.6-1 100% |  26.8 MiB/s |  82.3 KiB |  00m00s
+DEBUG util.py:459:  [ 47/139] Installing libcap-ng-0:0.8.5- 100% |  53.0 MiB/s | 162.8 KiB |  00m00s
+DEBUG util.py:459:  [ 48/139] Installing audit-libs-0:4.0.3 100% |  82.3 MiB/s | 421.3 KiB |  00m00s
+DEBUG util.py:459:  [ 49/139] Installing pam-libs-0:1.7.0-4 100% |  55.0 MiB/s | 225.3 KiB |  00m00s
+DEBUG util.py:459:  [ 50/139] Installing libcap-0:2.73-2.el 100% |  21.7 MiB/s | 511.8 KiB |  00m00s
+DEBUG util.py:459:  [ 51/139] Installing systemd-libs-0:257 100% | 146.0 MiB/s |   2.3 MiB |  00m00s
+DEBUG util.py:459:  [ 52/139] Installing libsmartcols-0:2.4 100% |  73.4 MiB/s | 225.6 KiB |  00m00s
+DEBUG util.py:459:  [ 53/139] Installing libsepol-0:3.8-1.e 100% | 132.0 MiB/s | 811.0 KiB |  00m00s
+DEBUG util.py:459:  [ 54/139] Installing libselinux-0:3.8-1 100% |  49.4 MiB/s | 202.3 KiB |  00m00s
+DEBUG util.py:459:  [ 55/139] Installing findutils-1:4.10.0 100% |  56.5 MiB/s |   1.9 MiB |  00m00s
+DEBUG util.py:459:  [ 56/139] Installing sed-0:4.9-4.eln145 100% |  28.7 MiB/s | 881.4 KiB |  00m00s
+DEBUG util.py:459:  [ 57/139] Installing libmount-0:2.40.4- 100% |  69.7 MiB/s | 356.9 KiB |  00m00s
+DEBUG util.py:459:  [ 58/139] Installing alternatives-0:1.3 100% |   4.3 MiB/s |  91.8 KiB |  00m00s
+DEBUG util.py:459:  [ 59/139] Installing lz4-libs-0:1.10.0- 100% |  48.5 MiB/s | 198.5 KiB |  00m00s
+DEBUG util.py:459:  [ 60/139] Installing lua-libs-0:5.4.7-3 100% |  53.7 MiB/s | 330.1 KiB |  00m00s
+DEBUG util.py:459:  [ 61/139] Installing libffi-0:3.4.7-2.e 100% |  38.1 MiB/s | 156.1 KiB |  00m00s
+DEBUG util.py:459:  [ 62/139] Installing libtasn1-0:4.20.0- 100% |  54.2 MiB/s | 222.2 KiB |  00m00s
+DEBUG util.py:459:  [ 63/139] Installing p11-kit-0:0.25.5-5 100% |  59.9 MiB/s |   2.4 MiB |  00m00s
+DEBUG util.py:459:  [ 64/139] Installing libunistring-0:1.1 100% | 174.6 MiB/s |   1.7 MiB |  00m00s
+DEBUG util.py:459:  [ 65/139] Installing libidn2-0:2.3.8-1. 100% |  55.3 MiB/s | 566.7 KiB |  00m00s
+DEBUG util.py:459:  [ 66/139] Installing libpsl-0:0.21.5-5. 100% |  43.5 MiB/s | 133.6 KiB |  00m00s
+DEBUG util.py:459:  [ 67/139] Installing p11-kit-trust-0:0. 100% |  12.3 MiB/s | 465.0 KiB |  00m00s
+DEBUG util.py:459:  [ 68/139] Installing zstd-0:1.5.7-1.eln 100% |  55.8 MiB/s |   1.5 MiB |  00m00s
+DEBUG util.py:459:  [ 69/139] Installing util-linux-core-0: 100% |  56.8 MiB/s |   2.4 MiB |  00m00s
+DEBUG util.py:459:  [ 70/139] Installing tar-2:1.35-5.eln14 100% |  79.1 MiB/s |   3.0 MiB |  00m00s
+DEBUG util.py:459:  [ 71/139] Installing libsemanage-0:3.8- 100% |  58.9 MiB/s | 361.8 KiB |  00m00s
+DEBUG util.py:459:  [ 72/139] Installing shadow-utils-2:4.1 100% |  56.8 MiB/s |   4.5 MiB |  00m00s
+DEBUG util.py:459:  [ 73/139] Installing systemd-standalone 100% |  16.1 MiB/s | 329.9 KiB |  00m00s
+DEBUG util.py:459:  [ 74/139] Installing zip-0:3.0-43.eln14 100% |  29.9 MiB/s | 766.4 KiB |  00m00s
+DEBUG util.py:459:  [ 75/139] Installing libfdisk-0:2.40.4- 100% |  82.0 MiB/s | 419.9 KiB |  00m00s
+DEBUG util.py:459:  [ 76/139] Installing libxml2-0:2.12.10- 100% |  63.1 MiB/s |   1.9 MiB |  00m00s
+DEBUG util.py:459:  [ 77/139] Installing bzip2-0:1.0.8-20.e 100% |   7.8 MiB/s | 175.8 KiB |  00m00s
+DEBUG util.py:459:  [ 78/139] Installing ed-0:1.21-2.eln145 100% |   7.3 MiB/s | 156.8 KiB |  00m00s
+DEBUG util.py:459:  [ 79/139] Installing patch-0:2.7.6-26.e 100% |  12.3 MiB/s | 263.9 KiB |  00m00s
+DEBUG util.py:459:  [ 80/139] Installing filesystem-srpm-ma 100% |  12.7 MiB/s |  38.9 KiB |  00m00s
+DEBUG util.py:459:  [ 81/139] Installing elfutils-default-y 100% | 145.9 KiB/s |   2.0 KiB |  00m00s
+DEBUG util.py:459:  [ 82/139] Installing elfutils-libs-0:0. 100% | 104.4 MiB/s | 748.2 KiB |  00m00s
+DEBUG util.py:459:  [ 83/139] Installing cpio-0:2.15-4.eln1 100% |  35.3 MiB/s |   1.1 MiB |  00m00s
+DEBUG util.py:459:  [ 84/139] Installing diffutils-0:3.10-9 100% |  46.0 MiB/s |   1.6 MiB |  00m00s
+DEBUG util.py:459:  [ 85/139] Installing jansson-0:2.14-2.e 100% |  23.1 MiB/s |  94.5 KiB |  00m00s
+DEBUG util.py:459:  [ 86/139] Installing libgomp-0:15.0.1-0 100% | 100.2 MiB/s | 512.8 KiB |  00m00s
+DEBUG util.py:459:  [ 87/139] Installing sqlite-libs-0:3.49 100% | 150.1 MiB/s |   1.5 MiB |  00m00s
+DEBUG util.py:459:  [ 88/139] Installing json-c-0:0.18-2.el 100% |  45.6 MiB/s | 139.9 KiB |  00m00s
+DEBUG util.py:459:  [ 89/139] Installing libpkgconf-0:2.3.0 100% |  44.0 MiB/s | 135.1 KiB |  00m00s
+DEBUG util.py:459:  [ 90/139] Installing pkgconf-0:2.3.0-2. 100% |   5.3 MiB/s | 115.0 KiB |  00m00s
+DEBUG util.py:459:  [ 91/139] Installing pkgconf-pkg-config 100% |  98.5 KiB/s |   1.8 KiB |  00m00s
+DEBUG util.py:459:  [ 92/139] Installing libbrotli-0:1.1.0- 100% | 127.2 MiB/s | 911.7 KiB |  00m00s
+DEBUG util.py:459:  [ 93/139] Installing libnghttp2-0:1.65. 100% |  64.8 MiB/s | 199.0 KiB |  00m00s
+DEBUG util.py:459:  [ 94/139] Installing keyutils-libs-0:1. 100% |  32.5 MiB/s |  99.8 KiB |  00m00s
+DEBUG util.py:459:  [ 95/139] Installing libcom_err-0:1.47. 100% |  54.8 MiB/s | 112.2 KiB |  00m00s
+DEBUG util.py:459:  [ 96/139] Installing libverto-0:0.3.2-1 100% |  23.2 MiB/s |  71.2 KiB |  00m00s
+DEBUG util.py:459:  [ 97/139] Installing libtool-ltdl-0:2.5 100% |  31.0 MiB/s |  95.1 KiB |  00m00s
+DEBUG util.py:459:  [ 98/139] Installing gdbm-libs-1:1.23-9 100% |  76.7 MiB/s | 235.7 KiB |  00m00s
+DEBUG util.py:459:  [ 99/139] Installing cyrus-sasl-lib-0:2 100% |  37.2 MiB/s | 913.2 KiB |  00m00s
+DEBUG util.py:459:  [100/139] Installing rust-toolset-srpm- 100% |   1.1 MiB/s |   2.3 KiB |  00m00s
+DEBUG util.py:459:  [101/139] Installing qt6-srpm-macros-0: 100% | 361.3 KiB/s | 740.0   B |  00m00s
+DEBUG util.py:459:  [102/139] Installing perl-srpm-macros-0 100% | 556.6 KiB/s |   1.1 KiB |  00m00s
+DEBUG util.py:459:  [103/139] Installing package-notes-srpm 100% |   1.0 MiB/s |   2.0 KiB |  00m00s
+DEBUG util.py:459:  [104/139] Installing openblas-srpm-macr 100% | 382.8 KiB/s | 392.0   B |  00m00s
+DEBUG util.py:459:  [105/139] Installing ocaml-srpm-macros- 100% |   2.1 MiB/s |   2.2 KiB |  00m00s
+DEBUG util.py:459:  [106/139] Installing kernel-srpm-macros 100% |   1.1 MiB/s |   2.3 KiB |  00m00s
+DEBUG util.py:459:  [107/139] Installing coreutils-common-0 100% | 150.7 MiB/s |  11.2 MiB |  00m00s
+DEBUG util.py:459:  [108/139] Installing openssl-libs-1:3.2 100% | 166.7 MiB/s |   6.3 MiB |  00m00s
+DEBUG util.py:459:  [109/139] Installing coreutils-0:9.6-2. 100% |  94.9 MiB/s |   8.2 MiB |  00m00s
+DEBUG util.py:459:  [110/139] Installing ca-certificates-0: 100% |   1.0 MiB/s |   2.4 MiB |  00m02s
+DEBUG util.py:459:  [111/139] Installing libarchive-0:3.7.7 100% |  81.0 MiB/s | 912.6 KiB |  00m00s
+DEBUG util.py:459:  [112/139] Installing krb5-libs-0:1.21.3 100% | 133.3 MiB/s |   2.5 MiB |  00m00s
+DEBUG util.py:459:  [113/139] Installing libssh-0:0.11.1-4. 100% |  95.6 MiB/s | 587.5 KiB |  00m00s
+DEBUG util.py:459:  [114/139] Installing gzip-0:1.13-3.eln1 100% |  16.8 MiB/s | 430.3 KiB |  00m00s
+DEBUG util.py:459:  [115/139] Installing rpm-sequoia-0:1.7. 100% | 176.9 MiB/s |   2.3 MiB |  00m00s
+DEBUG util.py:459:  [116/139] Installing rpm-libs-0:4.20.1- 100% | 119.6 MiB/s | 735.1 KiB |  00m00s
+DEBUG util.py:459:  [117/139] Installing rpm-build-libs-0:4 100% |  64.9 MiB/s | 199.4 KiB |  00m00s
+DEBUG util.py:459:  [118/139] Installing libevent-0:2.1.12- 100% | 135.6 MiB/s |   1.1 MiB |  00m00s
+DEBUG util.py:459:  [119/139] Installing openldap-0:2.6.9-3 100% |  85.6 MiB/s | 701.1 KiB |  00m00s
+DEBUG util.py:459:  [120/139] Installing libcurl-0:8.13.0~r 100% | 139.9 MiB/s | 859.6 KiB |  00m00s
+DEBUG util.py:459:  [121/139] Installing elfutils-debuginfo 100% |   6.5 MiB/s | 146.2 KiB |  00m00s
+DEBUG util.py:459:  [122/139] Installing binutils-0:2.44-3. 100% | 169.8 MiB/s |  29.4 MiB |  00m00s
+DEBUG util.py:459:  [123/139] Installing elfutils-0:0.192-8 100% |  84.9 MiB/s |   3.1 MiB |  00m00s
+DEBUG util.py:459:  [124/139] Installing gdb-minimal-0:16.2 100% | 156.7 MiB/s |  12.9 MiB |  00m00s
+DEBUG util.py:459:  [125/139] Installing debugedit-0:5.1-5. 100% |  11.5 MiB/s | 247.3 KiB |  00m00s
+DEBUG util.py:459:  [126/139] Installing curl-0:8.13.0~rc1- 100% |  11.2 MiB/s | 459.5 KiB |  00m00s
+DEBUG util.py:459:  [127/139] Installing rpm-0:4.20.1-1.eln 100% |  47.3 MiB/s |   2.7 MiB |  00m00s
+DEBUG util.py:459:  [128/139] Installing efi-srpm-macros-0: 100% |  13.4 MiB/s |  41.1 KiB |  00m00s
+DEBUG util.py:459:  [129/139] Installing lua-srpm-macros-0: 100% | 951.2 KiB/s |   1.9 KiB |  00m00s
+DEBUG util.py:459:  [130/139] Installing fonts-srpm-macros- 100% |  18.6 MiB/s |  57.0 KiB |  00m00s
+DEBUG util.py:459:  [131/139] Installing forge-srpm-macros- 100% |  13.1 MiB/s |  40.3 KiB |  00m00s
+DEBUG util.py:459:  [132/139] Installing go-srpm-macros-0:3 100% |  30.2 MiB/s |  61.8 KiB |  00m00s
+DEBUG util.py:459:  [133/139] Installing python-srpm-macros 100% |  17.0 MiB/s |  52.2 KiB |  00m00s
+DEBUG util.py:459:  [134/139] Installing redhat-rpm-config- 100% |  27.0 MiB/s | 193.5 KiB |  00m00s
+DEBUG util.py:459:  [135/139] Installing rpm-build-0:4.20.1 100% |  20.0 MiB/s | 533.1 KiB |  00m00s
+DEBUG util.py:459:  [136/139] Installing pyproject-srpm-mac 100% | 834.6 KiB/s |   2.5 KiB |  00m00s
+DEBUG util.py:459:  [137/139] Installing util-linux-0:2.40. 100% |  70.5 MiB/s |   6.6 MiB |  00m00s
+DEBUG util.py:459:  [138/139] Installing which-0:2.23-1.eln 100% |   5.6 MiB/s | 125.6 KiB |  00m00s
+DEBUG util.py:459:  [139/139] Installing info-0:7.2-3.eln14 100% | 105.1 KiB/s | 422.0 KiB |  00m04s
+DEBUG util.py:459:  Warning: skipped OpenPGP checks for 137 packages from repository: build
+DEBUG util.py:459:  Complete!
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/os-release
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/RPMS
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/RPMS
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SPECS
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SPECS
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SRPMS
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SRPMS
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SOURCES
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SOURCES
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/BUILD
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/BUILD
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/BUILDROOT
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/BUILDROOT
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/originals
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/originals
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['userdel', '-f', 'mockbuild', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:459:  userdel: user 'mockbuild' does not exist
+DEBUG util.py:608:  Child return code was: 6
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['groupdel', 'mock', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:459:  groupdel: group 'mock' does not exist
+DEBUG util.py:608:  Child return code was: 6
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['groupadd', 'mock', '-g', '425', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['useradd', 'mockbuild', '-o', '-u', '1000', '-g', '425', '-N', '-d', '/builddir', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:459:  useradd: warning: the home directory /builddir already exists.
+DEBUG util.py:459:  useradd: Not copying any file from skel directory into it.
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/.initialized
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'private,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,private,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.7zqdht6u:/etc/resolv.conf']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '37521849e5d844848a01014d529abb78', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.7zqdht6u:/etc/resolv.conf', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', '/bin/rpm', '-qa', '--root', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:461:  libgcc-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libssh-config-0.11.1-4.eln145.noarch
+DEBUG util.py:461:  publicsuffix-list-dafsa-20250116-1.eln145.noarch
+DEBUG util.py:461:  fedora-release-identity-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-gpg-keys-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-common-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-repos-eln-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  setup-2.15.0-14.eln146.noarch
+DEBUG util.py:461:  filesystem-3.18-38.eln146.aarch64
+DEBUG util.py:461:  pkgconf-m4-2.3.0-2.eln145.noarch
+DEBUG util.py:461:  pcre2-syntax-10.45-1.eln146.noarch
+DEBUG util.py:461:  ncurses-base-6.5-5.20250125.eln145.noarch
+DEBUG util.py:461:  glibc-minimal-langpack-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  ncurses-libs-6.5-5.20250125.eln145.aarch64
+DEBUG util.py:461:  glibc-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  bash-5.2.37-3.eln146.aarch64
+DEBUG util.py:461:  glibc-common-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  glibc-gconv-extra-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  zlib-ng-compat-2.2.4-2.eln146.aarch64
+DEBUG util.py:461:  bzip2-libs-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  xz-libs-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libuuid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libblkid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  gmp-6.3.0-3.eln146.aarch64
+DEBUG util.py:461:  readline-8.2-13.eln146.aarch64
+DEBUG util.py:461:  popt-1.19-8.eln145.aarch64
+DEBUG util.py:461:  libxcrypt-4.4.38-6.eln146.aarch64
+DEBUG util.py:461:  libstdc++-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libzstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  elfutils-libelf-0.192-8.eln145.aarch64
+DEBUG util.py:461:  libattr-2.5.2-5.eln145.aarch64
+DEBUG util.py:461:  libacl-2.3.2-3.eln145.aarch64
+DEBUG util.py:461:  dwz-0.15-9.eln145.aarch64
+DEBUG util.py:461:  mpfr-4.2.1-6.eln145.aarch64
+DEBUG util.py:461:  gawk-5.3.1-1.eln145.aarch64
+DEBUG util.py:461:  unzip-6.0-66.eln145.aarch64
+DEBUG util.py:461:  file-libs-5.46-1.eln145.aarch64
+DEBUG util.py:461:  file-5.46-1.eln145.aarch64
+DEBUG util.py:461:  crypto-policies-20250214-1.gitfd9b9b9.eln146.noarch
+DEBUG util.py:461:  pcre2-10.45-1.eln146.aarch64
+DEBUG util.py:461:  grep-3.11-10.eln145.aarch64
+DEBUG util.py:461:  xz-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libeconf-0.7.6-1.eln146.aarch64
+DEBUG util.py:461:  libcap-ng-0.8.5-4.eln145.aarch64
+DEBUG util.py:461:  audit-libs-4.0.3-2.eln145.aarch64
+DEBUG util.py:461:  pam-libs-1.7.0-4.eln145.aarch64
+DEBUG util.py:461:  libcap-2.73-2.eln145.aarch64
+DEBUG util.py:461:  systemd-libs-257.4-1.eln146.aarch64
+DEBUG util.py:461:  libsmartcols-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libsepol-3.8-1.eln145.aarch64
+DEBUG util.py:461:  libselinux-3.8-1.eln145.aarch64
+DEBUG util.py:461:  findutils-4.10.0-5.eln145.aarch64
+DEBUG util.py:461:  sed-4.9-4.eln145.aarch64
+DEBUG util.py:461:  libmount-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  alternatives-1.32-1.eln146.aarch64
+DEBUG util.py:461:  lz4-libs-1.10.0-2.eln145.aarch64
+DEBUG util.py:461:  lua-libs-5.4.7-3.eln146.aarch64
+DEBUG util.py:461:  libffi-3.4.7-2.eln146.aarch64
+DEBUG util.py:461:  libtasn1-4.20.0-1.eln146.aarch64
+DEBUG util.py:461:  p11-kit-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  libunistring-1.1-9.eln145.aarch64
+DEBUG util.py:461:  libidn2-2.3.8-1.eln146.aarch64
+DEBUG util.py:461:  libpsl-0.21.5-5.eln145.aarch64
+DEBUG util.py:461:  p11-kit-trust-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  zstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  util-linux-core-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  tar-1.35-5.eln145.aarch64
+DEBUG util.py:461:  libsemanage-3.8-1.eln145.aarch64
+DEBUG util.py:461:  shadow-utils-4.17.0-4.eln145.aarch64
+DEBUG util.py:461:  systemd-standalone-sysusers-257.4-1.eln146.aarch64
+DEBUG util.py:461:  zip-3.0-43.eln145.aarch64
+DEBUG util.py:461:  libfdisk-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libxml2-2.12.10-1.eln146.aarch64
+DEBUG util.py:461:  bzip2-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  ed-1.21-2.eln145.aarch64
+DEBUG util.py:461:  patch-2.7.6-26.eln145.aarch64
+DEBUG util.py:461:  filesystem-srpm-macros-3.18-38.eln146.noarch
+DEBUG util.py:461:  elfutils-default-yama-scope-0.192-8.eln145.noarch
+DEBUG util.py:461:  elfutils-libs-0.192-8.eln145.aarch64
+DEBUG util.py:461:  cpio-2.15-4.eln146.aarch64
+DEBUG util.py:461:  diffutils-3.10-9.eln145.aarch64
+DEBUG util.py:461:  jansson-2.14-2.eln145.aarch64
+DEBUG util.py:461:  libgomp-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  sqlite-libs-3.49.0-1.eln146.aarch64
+DEBUG util.py:461:  json-c-0.18-2.eln145.aarch64
+DEBUG util.py:461:  libpkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-pkg-config-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  libbrotli-1.1.0-6.eln145.aarch64
+DEBUG util.py:461:  libnghttp2-1.65.0-1.eln146.aarch64
+DEBUG util.py:461:  keyutils-libs-1.6.3-5.eln145.aarch64
+DEBUG util.py:461:  libcom_err-1.47.2-3.eln145.aarch64
+DEBUG util.py:461:  libverto-0.3.2-10.eln145.aarch64
+DEBUG util.py:461:  libtool-ltdl-2.5.4-4.eln145.aarch64
+DEBUG util.py:461:  gdbm-libs-1.23-9.eln145.aarch64
+DEBUG util.py:461:  cyrus-sasl-lib-2.1.28-30.eln145.aarch64
+DEBUG util.py:461:  rust-toolset-srpm-macros-1.85.0-5.eln146.noarch
+DEBUG util.py:461:  qt6-srpm-macros-6.8.2-2.eln146.noarch
+DEBUG util.py:461:  perl-srpm-macros-1-57.eln145.noarch
+DEBUG util.py:461:  package-notes-srpm-macros-0.5-13.eln145.noarch
+DEBUG util.py:461:  openblas-srpm-macros-2-19.eln145.noarch
+DEBUG util.py:461:  ocaml-srpm-macros-10-4.eln145.noarch
+DEBUG util.py:461:  kernel-srpm-macros-1.0-25.eln145.noarch
+DEBUG util.py:461:  coreutils-common-9.6-2.eln146.aarch64
+DEBUG util.py:461:  openssl-libs-3.2.4-3.eln146.aarch64
+DEBUG util.py:461:  coreutils-9.6-2.eln146.aarch64
+DEBUG util.py:461:  ca-certificates-2024.2.69_v8.0.401-5.eln145.noarch
+DEBUG util.py:461:  libarchive-3.7.7-4.eln146.aarch64
+DEBUG util.py:461:  krb5-libs-1.21.3-5.eln145.aarch64
+DEBUG util.py:461:  libssh-0.11.1-4.eln145.aarch64
+DEBUG util.py:461:  gzip-1.13-3.eln145.aarch64
+DEBUG util.py:461:  rpm-sequoia-1.7.0-2.eln146.aarch64
+DEBUG util.py:461:  rpm-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  rpm-build-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  libevent-2.1.12-15.eln145.aarch64
+DEBUG util.py:461:  openldap-2.6.9-3.eln145.aarch64
+DEBUG util.py:461:  libcurl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  elfutils-debuginfod-client-0.192-8.eln145.aarch64
+DEBUG util.py:461:  binutils-2.44-3.eln146.aarch64
+DEBUG util.py:461:  elfutils-0.192-8.eln145.aarch64
+DEBUG util.py:461:  gdb-minimal-16.2-1.eln146.aarch64
+DEBUG util.py:461:  debugedit-5.1-5.eln146.aarch64
+DEBUG util.py:461:  curl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  rpm-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  efi-srpm-macros-6-3.eln146.noarch
+DEBUG util.py:461:  lua-srpm-macros-1-15.eln145.noarch
+DEBUG util.py:461:  fonts-srpm-macros-2.0.5-21.eln145.noarch
+DEBUG util.py:461:  forge-srpm-macros-0.4.0-2.eln145.noarch
+DEBUG util.py:461:  go-srpm-macros-3.6.0-1.eln144.noarch
+DEBUG util.py:461:  python-srpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  redhat-rpm-config-342-2.eln145.noarch
+DEBUG util.py:461:  rpm-build-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  pyproject-srpm-macros-1.17.0-1.eln146.noarch
+DEBUG util.py:461:  util-linux-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  which-2.23-1.eln145.aarch64
+DEBUG util.py:461:  info-7.2-3.eln145.aarch64
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+INFO backend.py:228:  Installed packages:
+INFO backend.py:229:  alternatives-1.32-1.eln146.aarch64
+audit-libs-4.0.3-2.eln145.aarch64
+bash-5.2.37-3.eln146.aarch64
+binutils-2.44-3.eln146.aarch64
+bzip2-1.0.8-20.eln145.aarch64
+bzip2-libs-1.0.8-20.eln145.aarch64
+ca-certificates-2024.2.69_v8.0.401-5.eln145.noarch
+coreutils-9.6-2.eln146.aarch64
+coreutils-common-9.6-2.eln146.aarch64
+cpio-2.15-4.eln146.aarch64
+crypto-policies-20250214-1.gitfd9b9b9.eln146.noarch
+curl-8.13.0~rc1-2.eln146.aarch64
+cyrus-sasl-lib-2.1.28-30.eln145.aarch64
+debugedit-5.1-5.eln146.aarch64
+diffutils-3.10-9.eln145.aarch64
+dwz-0.15-9.eln145.aarch64
+ed-1.21-2.eln145.aarch64
+efi-srpm-macros-6-3.eln146.noarch
+elfutils-0.192-8.eln145.aarch64
+elfutils-debuginfod-client-0.192-8.eln145.aarch64
+elfutils-default-yama-scope-0.192-8.eln145.noarch
+elfutils-libelf-0.192-8.eln145.aarch64
+elfutils-libs-0.192-8.eln145.aarch64
+fedora-gpg-keys-43-0.1.eln146.noarch
+fedora-release-common-43-0.7.eln147.noarch
+fedora-release-eln-43-0.7.eln147.noarch
+fedora-release-identity-eln-43-0.7.eln147.noarch
+fedora-repos-eln-43-0.1.eln146.noarch
+file-5.46-1.eln145.aarch64
+file-libs-5.46-1.eln145.aarch64
+filesystem-3.18-38.eln146.aarch64
+filesystem-srpm-macros-3.18-38.eln146.noarch
+findutils-4.10.0-5.eln145.aarch64
+fonts-srpm-macros-2.0.5-21.eln145.noarch
+forge-srpm-macros-0.4.0-2.eln145.noarch
+gawk-5.3.1-1.eln145.aarch64
+gdb-minimal-16.2-1.eln146.aarch64
+gdbm-libs-1.23-9.eln145.aarch64
+glibc-2.41.9000-2.eln146.aarch64
+glibc-common-2.41.9000-2.eln146.aarch64
+glibc-gconv-extra-2.41.9000-2.eln146.aarch64
+glibc-minimal-langpack-2.41.9000-2.eln146.aarch64
+gmp-6.3.0-3.eln146.aarch64
+go-srpm-macros-3.6.0-1.eln144.noarch
+grep-3.11-10.eln145.aarch64
+gzip-1.13-3.eln145.aarch64
+info-7.2-3.eln145.aarch64
+jansson-2.14-2.eln145.aarch64
+json-c-0.18-2.eln145.aarch64
+kernel-srpm-macros-1.0-25.eln145.noarch
+keyutils-libs-1.6.3-5.eln145.aarch64
+krb5-libs-1.21.3-5.eln145.aarch64
+libacl-2.3.2-3.eln145.aarch64
+libarchive-3.7.7-4.eln146.aarch64
+libattr-2.5.2-5.eln145.aarch64
+libblkid-2.40.4-7.eln146.aarch64
+libbrotli-1.1.0-6.eln145.aarch64
+libcap-2.73-2.eln145.aarch64
+libcap-ng-0.8.5-4.eln145.aarch64
+libcom_err-1.47.2-3.eln145.aarch64
+libcurl-8.13.0~rc1-2.eln146.aarch64
+libeconf-0.7.6-1.eln146.aarch64
+libevent-2.1.12-15.eln145.aarch64
+libfdisk-2.40.4-7.eln146.aarch64
+libffi-3.4.7-2.eln146.aarch64
+libgcc-15.0.1-0.10.eln146.aarch64
+libgomp-15.0.1-0.10.eln146.aarch64
+libidn2-2.3.8-1.eln146.aarch64
+libmount-2.40.4-7.eln146.aarch64
+libnghttp2-1.65.0-1.eln146.aarch64
+libpkgconf-2.3.0-2.eln145.aarch64
+libpsl-0.21.5-5.eln145.aarch64
+libselinux-3.8-1.eln145.aarch64
+libsemanage-3.8-1.eln145.aarch64
+libsepol-3.8-1.eln145.aarch64
+libsmartcols-2.40.4-7.eln146.aarch64
+libssh-0.11.1-4.eln145.aarch64
+libssh-config-0.11.1-4.eln145.noarch
+libstdc++-15.0.1-0.10.eln146.aarch64
+libtasn1-4.20.0-1.eln146.aarch64
+libtool-ltdl-2.5.4-4.eln145.aarch64
+libunistring-1.1-9.eln145.aarch64
+libuuid-2.40.4-7.eln146.aarch64
+libverto-0.3.2-10.eln145.aarch64
+libxcrypt-4.4.38-6.eln146.aarch64
+libxml2-2.12.10-1.eln146.aarch64
+libzstd-1.5.7-1.eln146.aarch64
+lua-libs-5.4.7-3.eln146.aarch64
+lua-srpm-macros-1-15.eln145.noarch
+lz4-libs-1.10.0-2.eln145.aarch64
+mpfr-4.2.1-6.eln145.aarch64
+ncurses-base-6.5-5.20250125.eln145.noarch
+ncurses-libs-6.5-5.20250125.eln145.aarch64
+ocaml-srpm-macros-10-4.eln145.noarch
+openblas-srpm-macros-2-19.eln145.noarch
+openldap-2.6.9-3.eln145.aarch64
+openssl-libs-3.2.4-3.eln146.aarch64
+p11-kit-0.25.5-5.eln145.aarch64
+p11-kit-trust-0.25.5-5.eln145.aarch64
+package-notes-srpm-macros-0.5-13.eln145.noarch
+pam-libs-1.7.0-4.eln145.aarch64
+patch-2.7.6-26.eln145.aarch64
+pcre2-10.45-1.eln146.aarch64
+pcre2-syntax-10.45-1.eln146.noarch
+perl-srpm-macros-1-57.eln145.noarch
+pkgconf-2.3.0-2.eln145.aarch64
+pkgconf-m4-2.3.0-2.eln145.noarch
+pkgconf-pkg-config-2.3.0-2.eln145.aarch64
+popt-1.19-8.eln145.aarch64
+publicsuffix-list-dafsa-20250116-1.eln145.noarch
+pyproject-srpm-macros-1.17.0-1.eln146.noarch
+python-srpm-macros-3.13-4.eln145.noarch
+qt6-srpm-macros-6.8.2-2.eln146.noarch
+readline-8.2-13.eln146.aarch64
+redhat-rpm-config-342-2.eln145.noarch
+rpm-4.20.1-1.eln146.aarch64
+rpm-build-4.20.1-1.eln146.aarch64
+rpm-build-libs-4.20.1-1.eln146.aarch64
+rpm-libs-4.20.1-1.eln146.aarch64
+rpm-sequoia-1.7.0-2.eln146.aarch64
+rust-toolset-srpm-macros-1.85.0-5.eln146.noarch
+sed-4.9-4.eln145.aarch64
+setup-2.15.0-14.eln146.noarch
+shadow-utils-4.17.0-4.eln145.aarch64
+sqlite-libs-3.49.0-1.eln146.aarch64
+systemd-libs-257.4-1.eln146.aarch64
+systemd-standalone-sysusers-257.4-1.eln146.aarch64
+tar-1.35-5.eln145.aarch64
+unzip-6.0-66.eln145.aarch64
+util-linux-2.40.4-7.eln146.aarch64
+util-linux-core-2.40.4-7.eln146.aarch64
+which-2.23-1.eln145.aarch64
+xz-5.6.3-3.eln145.aarch64
+xz-libs-5.6.3-3.eln145.aarch64
+zip-3.0-43.eln145.aarch64
+zlib-ng-compat-2.2.4-2.eln146.aarch64
+zstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root
+INFO buildroot.py:665:  Mock Version: 6.0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/results
+INFO buildroot.py:316:  calling preinit hooks
+DEBUG buildroot.py:721:  create skeleton dirs
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/dbus
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/log
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/cache/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/cache/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/tmp/ccache
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf/vars
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum.repos.d
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/pts
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/shm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/mapper
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/mapper
+DEBUG buildroot.py:865:  kernel version == 6.12.10-200.fc41.aarch64
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/fstab
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum/yum.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf/dnf.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/log/yum.log
+DEBUG buildroot.py:330:  rootdir = /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root
+DEBUG buildroot.py:331:  resultdir = /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/results
+DEBUG package_manager.py:63:  searching for 'dnf5' package manager or alternatives
+INFO buildroot.py:179:  Package manager dnf5 detected and used (fallback)
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/mock
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust with files from /etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/./extracted
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/./source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/edk2
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/java
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/openssl
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/pem
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/pem/directory-hash
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/source/anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/source/blocklist
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source with files from /usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source/./anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source/./blocklist
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share
+DEBUG package_manager.py:388:  Copying /usr/share/distribution-gpg-keys to the bootstrap chroot
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['cp', '-a', '/usr/share/distribution-gpg-keys', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf
+DEBUG package_manager.py:689:  configure DNF vars
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc
+DEBUG buildroot.py:38:  method _make_users skipped in bootstrap
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/.initialized
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/result
+INFO buildroot.py:316:  calling preinit hooks
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/usr/bin/lscpu'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:461:  Architecture:                         aarch64
+DEBUG util.py:461:  CPU op-mode(s):                       32-bit, 64-bit
+DEBUG util.py:461:  Byte Order:                           Little Endian
+DEBUG util.py:461:  CPU(s):                               12
+DEBUG util.py:461:  On-line CPU(s) list:                  0-11
+DEBUG util.py:461:  Vendor ID:                            ARM
+DEBUG util.py:461:  Model name:                           Neoverse-N1
+DEBUG util.py:461:  Model:                                1
+DEBUG util.py:461:  Thread(s) per core:                   1
+DEBUG util.py:461:  Core(s) per socket:                   1
+DEBUG util.py:461:  Socket(s):                            12
+DEBUG util.py:461:  Stepping:                             r3p1
+DEBUG util.py:461:  BogoMIPS:                             50.00
+DEBUG util.py:461:  Flags:                                fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp
+DEBUG util.py:461:  NUMA node(s):                         1
+DEBUG util.py:461:  NUMA node0 CPU(s):                    0-11
+DEBUG util.py:461:  Vulnerability Gather data sampling:   Not affected
+DEBUG util.py:461:  Vulnerability Itlb multihit:          Not affected
+DEBUG util.py:461:  Vulnerability L1tf:                   Not affected
+DEBUG util.py:461:  Vulnerability Mds:                    Not affected
+DEBUG util.py:461:  Vulnerability Meltdown:               Not affected
+DEBUG util.py:461:  Vulnerability Mmio stale data:        Not affected
+DEBUG util.py:461:  Vulnerability Reg file data sampling: Not affected
+DEBUG util.py:461:  Vulnerability Retbleed:               Not affected
+DEBUG util.py:461:  Vulnerability Spec rstack overflow:   Not affected
+DEBUG util.py:461:  Vulnerability Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl
+DEBUG util.py:461:  Vulnerability Spectre v1:             Mitigation; __user pointer sanitization
+DEBUG util.py:461:  Vulnerability Spectre v2:             Mitigation; CSV2, BHB
+DEBUG util.py:461:  Vulnerability Srbds:                  Not affected
+DEBUG util.py:461:  Vulnerability Tsx async abort:        Not affected
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/free'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:461:                 total        used        free      shared  buff/cache   available
+DEBUG util.py:461:  Mem:        36854628     1205244    13262828         256    22805244    35649384
+DEBUG util.py:461:  Swap:        8388604       98548     8290056
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/df', '-H', '-T', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/cache/mock'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:461:  Filesystem     Type   Size  Used Avail Use% Mounted on
+DEBUG util.py:461:  /dev/vda3      btrfs  313G   28G  280G  10% /
+DEBUG util.py:461:  /dev/vda3      btrfs  313G   28G  280G  10% /
+DEBUG util.py:608:  Child return code was: 0
+DEBUG buildroot.py:721:  create skeleton dirs
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/dbus
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/log
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/cache/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/cache/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/tmp/ccache
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf/vars
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum.repos.d
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/mapper
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/mapper
+DEBUG buildroot.py:865:  kernel version == 6.12.10-200.fc41.aarch64
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/fstab
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum/yum.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf/dnf.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/log/yum.log
+DEBUG buildroot.py:330:  rootdir = /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG buildroot.py:331:  resultdir = /var/lib/mock/eln-build-side-108102-58033177-6561774/result
+INFO buildroot.py:179:  Package manager dnf5 detected and used (direct choice)
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/mock
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust with files from /etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/./extracted
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/./source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/edk2
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/java
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/openssl
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/pem
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/pem/directory-hash
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/source/anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/source/blocklist
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source with files from /usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source/./anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source/./blocklist
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf
+DEBUG package_manager.py:689:  configure DNF vars
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['userdel', '-f', 'mockbuild', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['groupdel', 'mock', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['groupadd', 'mock', '-g', '425', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['useradd', 'mockbuild', '-o', '-u', '1000', '-g', '425', '-N', '-d', '/builddir', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:459:  useradd: warning: the home directory /builddir already exists.
+DEBUG util.py:459:  useradd: Not copying any file from skel directory into it.
+DEBUG util.py:459:  Creating mailbox file: File exists
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/.initialized
+INFO backend.py:386:  Running in chroot: ['uname -r']
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.9ifnsjkc:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', 'c34d371f54224515b74859c7e5f2ea32', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.9ifnsjkc:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', '/bin/sh', '-c', 'uname -r'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:461:  6.12.10-200.fc41.aarch64
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root
+INFO buildroot.py:665:  Mock Version: 6.0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/results
+INFO buildroot.py:316:  calling preinit hooks
+DEBUG buildroot.py:721:  create skeleton dirs
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/dbus
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/log
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/cache/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/cache/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/tmp/ccache
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf/vars
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum.repos.d
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum.repos.d
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/proc
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/sys
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/pts
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/shm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/mapper
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/dev/mapper
+DEBUG buildroot.py:865:  kernel version == 6.12.10-200.fc41.aarch64
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/fstab
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/yum/yum.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf/dnf.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/log/yum.log
+DEBUG buildroot.py:330:  rootdir = /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root
+DEBUG buildroot.py:331:  resultdir = /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/results
+DEBUG package_manager.py:63:  searching for 'dnf5' package manager or alternatives
+INFO buildroot.py:179:  Package manager dnf5 detected and used (fallback)
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/mock
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust with files from /etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/./extracted
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/./source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/edk2
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/java
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/openssl
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/pem
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/extracted/pem/directory-hash
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/source/anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/pki/ca-trust/source/blocklist
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source with files from /usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source/./anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share/pki/ca-trust-source/./blocklist
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share
+DEBUG package_manager.py:388:  Copying /usr/share/distribution-gpg-keys to the bootstrap chroot
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['cp', '-a', '/usr/share/distribution-gpg-keys', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/usr/share'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc/dnf
+DEBUG package_manager.py:689:  configure DNF vars
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/etc
+DEBUG buildroot.py:38:  method _cleanup_homedir skipped in bootstrap
+DEBUG buildroot.py:38:  method _setup_build_dirs skipped in bootstrap
+DEBUG buildroot.py:38:  method _make_users skipped in bootstrap
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/.initialized
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/result
+INFO buildroot.py:316:  calling preinit hooks
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/usr/bin/lscpu'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:461:  Architecture:                         aarch64
+DEBUG util.py:461:  CPU op-mode(s):                       32-bit, 64-bit
+DEBUG util.py:461:  Byte Order:                           Little Endian
+DEBUG util.py:461:  CPU(s):                               12
+DEBUG util.py:461:  On-line CPU(s) list:                  0-11
+DEBUG util.py:461:  Vendor ID:                            ARM
+DEBUG util.py:461:  Model name:                           Neoverse-N1
+DEBUG util.py:461:  Model:                                1
+DEBUG util.py:461:  Thread(s) per core:                   1
+DEBUG util.py:461:  Core(s) per socket:                   1
+DEBUG util.py:461:  Socket(s):                            12
+DEBUG util.py:461:  Stepping:                             r3p1
+DEBUG util.py:461:  BogoMIPS:                             50.00
+DEBUG util.py:461:  Flags:                                fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp
+DEBUG util.py:461:  NUMA node(s):                         1
+DEBUG util.py:461:  NUMA node0 CPU(s):                    0-11
+DEBUG util.py:461:  Vulnerability Gather data sampling:   Not affected
+DEBUG util.py:461:  Vulnerability Itlb multihit:          Not affected
+DEBUG util.py:461:  Vulnerability L1tf:                   Not affected
+DEBUG util.py:461:  Vulnerability Mds:                    Not affected
+DEBUG util.py:461:  Vulnerability Meltdown:               Not affected
+DEBUG util.py:461:  Vulnerability Mmio stale data:        Not affected
+DEBUG util.py:461:  Vulnerability Reg file data sampling: Not affected
+DEBUG util.py:461:  Vulnerability Retbleed:               Not affected
+DEBUG util.py:461:  Vulnerability Spec rstack overflow:   Not affected
+DEBUG util.py:461:  Vulnerability Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl
+DEBUG util.py:461:  Vulnerability Spectre v1:             Mitigation; __user pointer sanitization
+DEBUG util.py:461:  Vulnerability Spectre v2:             Mitigation; CSV2, BHB
+DEBUG util.py:461:  Vulnerability Srbds:                  Not affected
+DEBUG util.py:461:  Vulnerability Tsx async abort:        Not affected
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/free'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:461:                 total        used        free      shared  buff/cache   available
+DEBUG util.py:461:  Mem:        36854628     1271352    13196252         256    22805712    35583276
+DEBUG util.py:461:  Swap:        8388604       98548     8290056
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/df', '-H', '-T', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/cache/mock'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:461:  Filesystem     Type   Size  Used Avail Use% Mounted on
+DEBUG util.py:461:  /dev/vda3      btrfs  313G   28G  280G  10% /
+DEBUG util.py:461:  /dev/vda3      btrfs  313G   28G  280G  10% /
+DEBUG util.py:608:  Child return code was: 0
+DEBUG buildroot.py:721:  create skeleton dirs
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/lib/dbus
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/log
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/cache/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/cache/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/rpm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/tmp/ccache
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/tmp
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf/vars
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum.repos.d
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum.repos.d
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/mapper
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/mapper
+DEBUG buildroot.py:865:  kernel version == 6.12.10-200.fc41.aarch64
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/fstab
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/yum/yum.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf/dnf.conf
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/var/log/yum.log
+DEBUG buildroot.py:330:  rootdir = /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG buildroot.py:331:  resultdir = /var/lib/mock/eln-build-side-108102-58033177-6561774/result
+INFO buildroot.py:179:  Package manager dnf5 detected and used (direct choice)
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/mock
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust with files from /etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/./extracted
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/./source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/edk2
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/java
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/openssl
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/pem
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/extracted/pem/directory-hash
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/source/anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/pki/ca-trust/source/blocklist
+DEBUG file_util.py:158:  Updating files in /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source with files from /usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source/./anchors
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/usr/share/pki/ca-trust-source/./blocklist
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/etc/dnf
+DEBUG package_manager.py:689:  configure DNF vars
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['rpm', '-q', 'rpm', 'rpm-sequoia', 'python3-dnf', 'python3-dnf-plugins-core', 'yum', 'yum-utils', 'dnf5', 'dnf5-plugins', '--root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:461:  rpm-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  rpm-sequoia-1.7.0-2.eln146.aarch64
+DEBUG util.py:461:  package python3-dnf is not installed
+DEBUG util.py:461:  package python3-dnf-plugins-core is not installed
+DEBUG util.py:461:  package yum is not installed
+DEBUG util.py:461:  package yum-utils is not installed
+DEBUG util.py:461:  dnf5-5.2.11.0-1.eln146.aarch64
+DEBUG util.py:461:  dnf5-plugins-5.2.11.0-1.eln146.aarch64
+DEBUG util.py:608:  Child return code was: 4
+INFO package_manager.py:201:  Buildroot is handled by package management installed into bootstrap:
+  rpm-4.20.1-1.eln146.aarch64
+  rpm-sequoia-1.7.0-2.eln146.aarch64
+  dnf5-5.2.11.0-1.eln146.aarch64
+  dnf5-plugins-5.2.11.0-1.eln146.aarch64
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/RPMS
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/RPMS
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SPECS
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SPECS
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SRPMS
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SRPMS
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SOURCES
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/BUILD
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/BUILD
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/BUILDROOT
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/BUILDROOT
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/originals
+DEBUG file_util.py:21:  created dir: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/originals
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['userdel', '-f', 'mockbuild', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['groupdel', 'mock', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['groupadd', 'mock', '-g', '425', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['useradd', 'mockbuild', '-o', '-u', '1000', '-g', '425', '-N', '-d', '/builddir', '--prefix', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:459:  useradd: warning: the home directory /builddir already exists.
+DEBUG util.py:459:  useradd: Not copying any file from skel directory into it.
+DEBUG util.py:459:  Creating mailbox file: File exists
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:30:  touching file: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/.initialized
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', 'e7b5c1b1af0d4e6fa9018ebe1976e520', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '-a', '-u', 'mockbuild', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', '/bin/rpm', '-Uvh', '--nodeps', '/builddir/build/originals/python-boto3-1.37.14-1.eln147.src.rpm'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:461:  Updating / installing...
+DEBUG util.py:461:  python-boto3-1.37.14-1.eln147         ########################################
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '68a08eb27af642a593fb8326dd4ded07', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '-a', '-u', 'mockbuild', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', '/bin/rpm', '-qpl', '/builddir/build/originals/python-boto3-1.37.14-1.eln147.src.rpm'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:461:  boto3-1.37.14.tar.gz
+DEBUG util.py:461:  python-boto3.spec
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '739850917ab04650a977c92786c6ebcf', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv.i0e8y6hz:/etc/resolv.conf', '--bind=/dev/btrfs-control', '--bind=/dev/mapper/control', '--bind=/dev/fuse', '--bind=/dev/loop-control', '--bind=/dev/loop0', '--bind=/dev/loop1', '--bind=/dev/loop2', '--bind=/dev/loop3', '--bind=/dev/loop4', '--bind=/dev/loop5', '--bind=/dev/loop6', '--bind=/dev/loop7', '--bind=/dev/loop8', '--bind=/dev/loop9', '--bind=/dev/loop10', '--bind=/dev/loop11', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', '/bin/sh', '-c', 'case $(rpmbuild --help) in *--noclean*) exit 0; esac; exit 1'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/proc', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/sys', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'devpts', '-o', 'gid=5,mode=0620,ptmxmode=0666,newinstance', 'devpts', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'bind', '/tmp/mock-selinux-plugin.id6ehnoj', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'private,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,private,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir
+DEBUG package_manager.py:295:  ['/usr/bin/dnf5', 'builddep', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root//builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.src.rpm', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing']
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '786b0d90515b4cbc89d49d270ec011d6', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--setenv=LC_MESSAGES=C.UTF-8', '--resolv-conf=off', '/usr/bin/dnf5', 'builddep', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root//builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.src.rpm', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing', '--setopt=tsflags=nocontexts'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'LC_MESSAGES': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:459:  Updating and loading repositories:
+DEBUG util.py:459:   build                                  100% | 166.4 KiB/s |   3.5 KiB |  00m00s
+DEBUG util.py:459:  Repositories loaded.
+DEBUG util.py:459:  Package "util-linux-core-2.40.4-7.eln146.aarch64" is already installed.
+DEBUG util.py:461:  Package                 Arch    Version         Repository      Size
+DEBUG util.py:461:  Installing:
+DEBUG util.py:461:   python3-devel          aarch64 3.13.2-2.eln146 build        1.8 MiB
+DEBUG util.py:461:   python3-pytest         noarch  8.3.5-2.eln146  build        3.7 MiB
+DEBUG util.py:461:   python3-pytest-xdist   noarch  3.6.1-5.eln145  build      419.9 KiB
+DEBUG util.py:461:  Installing dependencies:
+DEBUG util.py:461:   expat                  aarch64 2.7.0-1.eln146  build      352.7 KiB
+DEBUG util.py:461:   mpdecimal              aarch64 4.0.0-2.eln146  build      280.8 KiB
+DEBUG util.py:461:   python-pip-wheel       noarch  24.3.1-2.eln145 build        1.2 MiB
+DEBUG util.py:461:   python-rpm-macros      noarch  3.13-4.eln145   build       22.1 KiB
+DEBUG util.py:461:   python3                aarch64 3.13.2-2.eln146 build       83.6 KiB
+DEBUG util.py:461:   python3-execnet        noarch  2.1.1-5.eln145  build      915.3 KiB
+DEBUG util.py:461:   python3-iniconfig      noarch  1.1.1-25.eln145 build       20.6 KiB
+DEBUG util.py:461:   python3-libs           aarch64 3.13.2-2.eln146 build       42.4 MiB
+DEBUG util.py:461:   python3-packaging      noarch  24.2-3.eln145   build      558.3 KiB
+DEBUG util.py:461:   python3-pluggy         noarch  1.5.0-2.eln145  build      193.2 KiB
+DEBUG util.py:461:   python3-rpm-generators noarch  14-12.eln145    build       81.7 KiB
+DEBUG util.py:461:   python3-rpm-macros     noarch  3.13-4.eln145   build        6.4 KiB
+DEBUG util.py:461:   tzdata                 noarch  2025a-1.eln146  build        1.6 MiB
+DEBUG util.py:461:  Transaction Summary:
+DEBUG util.py:461:   Installing:        16 packages
+DEBUG util.py:459:  Total size of inbound packages is 12 MiB. Need to download 12 MiB.
+DEBUG util.py:459:  After this operation, 54 MiB extra will be used (install 54 MiB, remove 0 B).
+DEBUG util.py:459:  [ 1/16] python3-pytest-0:8.3.5-2.eln146 100% |  23.1 MiB/s | 732.1 KiB |  00m00s
+DEBUG util.py:459:  [ 2/16] python3-0:3.13.2-2.eln146.aarch 100% |   7.0 MiB/s |  28.6 KiB |  00m00s
+DEBUG util.py:459:  [ 3/16] python3-pytest-xdist-0:3.6.1-5. 100% |   2.5 MiB/s | 100.7 KiB |  00m00s
+DEBUG util.py:459:  [ 4/16] python3-iniconfig-0:1.1.1-25.el 100% |   3.0 MiB/s |  18.2 KiB |  00m00s
+DEBUG util.py:459:  [ 5/16] python3-devel-0:3.13.2-2.eln146 100% |   7.5 MiB/s | 358.7 KiB |  00m00s
+DEBUG util.py:459:  [ 6/16] python3-packaging-0:24.2-3.eln1 100% |  23.4 MiB/s | 143.5 KiB |  00m00s
+DEBUG util.py:459:  [ 7/16] python3-pluggy-0:1.5.0-2.eln145 100% |   6.5 MiB/s |  53.5 KiB |  00m00s
+DEBUG util.py:459:  [ 8/16] expat-0:2.7.0-1.eln146.aarch64  100% |  18.2 MiB/s | 112.0 KiB |  00m00s
+DEBUG util.py:459:  [ 9/16] mpdecimal-0:4.0.0-2.eln146.aarc 100% |  18.7 MiB/s |  95.6 KiB |  00m00s
+DEBUG util.py:459:  [10/16] python-pip-wheel-0:24.3.1-2.eln 100% |  75.3 MiB/s |   1.2 MiB |  00m00s
+DEBUG util.py:459:  [11/16] python3-libs-0:3.13.2-2.eln146. 100% | 125.8 MiB/s |   8.7 MiB |  00m00s
+DEBUG util.py:459:  [12/16] python3-execnet-0:2.1.1-5.eln14 100% |   4.6 MiB/s | 243.5 KiB |  00m00s
+DEBUG util.py:459:  [13/16] python-rpm-macros-0:3.13-4.eln1 100% |   5.5 MiB/s |  17.0 KiB |  00m00s
+DEBUG util.py:459:  [14/16] tzdata-0:2025a-1.eln146.noarch  100% |  16.1 MiB/s | 429.6 KiB |  00m00s
+DEBUG util.py:459:  [15/16] python3-rpm-generators-0:14-12. 100% |   4.8 MiB/s |  29.2 KiB |  00m00s
+DEBUG util.py:459:  [16/16] python3-rpm-macros-0:3.13-4.eln 100% |   2.9 MiB/s |  11.8 KiB |  00m00s
+DEBUG util.py:459:  --------------------------------------------------------------------------------
+DEBUG util.py:459:  [16/16] Total                           100% | 104.3 MiB/s |  12.2 MiB |  00m00s
+DEBUG util.py:459:  Running transaction
+DEBUG util.py:459:  [ 1/18] Verify package files            100% | 372.0   B/s |  16.0   B |  00m00s
+DEBUG util.py:459:  [ 2/18] Prepare transaction             100% | 390.0   B/s |  16.0   B |  00m00s
+DEBUG util.py:459:  [ 3/18] Installing python-rpm-macros-0: 100% |   7.4 MiB/s |  22.8 KiB |  00m00s
+DEBUG util.py:459:  [ 4/18] Installing python3-rpm-macros-0 100% |   1.6 MiB/s |   6.7 KiB |  00m00s
+DEBUG util.py:459:  [ 5/18] Installing tzdata-0:2025a-1.eln 100% |  13.6 MiB/s |   1.9 MiB |  00m00s
+DEBUG util.py:459:  [ 6/18] Installing python-pip-wheel-0:2 100% | 248.8 MiB/s |   1.2 MiB |  00m00s
+DEBUG util.py:459:  [ 7/18] Installing mpdecimal-0:4.0.0-2. 100% |  68.9 MiB/s | 282.3 KiB |  00m00s
+DEBUG util.py:459:  [ 8/18] Installing expat-0:2.7.0-1.eln1 100% |  12.8 MiB/s | 354.8 KiB |  00m00s
+DEBUG util.py:459:  [ 9/18] Installing python3-libs-0:3.13. 100% | 115.5 MiB/s |  42.7 MiB |  00m00s
+DEBUG util.py:459:  [10/18] Installing python3-0:3.13.2-2.e 100% |   4.0 MiB/s |  85.4 KiB |  00m00s
+DEBUG util.py:459:  [11/18] Installing python3-packaging-0: 100% |  55.7 MiB/s | 570.6 KiB |  00m00s
+DEBUG util.py:459:  [12/18] Installing python3-rpm-generato 100% |  27.0 MiB/s |  82.9 KiB |  00m00s
+DEBUG util.py:459:  [13/18] Installing python3-iniconfig-0: 100% |   7.7 MiB/s |  23.6 KiB |  00m00s
+DEBUG util.py:459:  [14/18] Installing python3-pluggy-0:1.5 100% |  32.5 MiB/s | 199.5 KiB |  00m00s
+DEBUG util.py:459:  [15/18] Installing python3-pytest-0:8.3 100% |  66.5 MiB/s |   3.8 MiB |  00m00s
+DEBUG util.py:459:  [16/18] Installing python3-execnet-0:2. 100% |  53.8 MiB/s | 937.0 KiB |  00m00s
+DEBUG util.py:459:  [17/18] Installing python3-pytest-xdist 100% |  42.2 MiB/s | 432.1 KiB |  00m00s
+DEBUG util.py:459:  [18/18] Installing python3-devel-0:3.13 100% |   2.8 MiB/s |   1.8 MiB |  00m01s
+DEBUG util.py:459:  Warning: skipped OpenPGP checks for 16 packages from repository: build
+DEBUG util.py:459:  Complete!
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'private,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,private,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', 'fd938d3119484c9e8f41fac86ec02f22', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', '/bin/rpm', '-qa', '--root', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:461:  libgcc-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libssh-config-0.11.1-4.eln145.noarch
+DEBUG util.py:461:  publicsuffix-list-dafsa-20250116-1.eln145.noarch
+DEBUG util.py:461:  fedora-release-identity-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-gpg-keys-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-common-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-repos-eln-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  setup-2.15.0-14.eln146.noarch
+DEBUG util.py:461:  filesystem-3.18-38.eln146.aarch64
+DEBUG util.py:461:  pkgconf-m4-2.3.0-2.eln145.noarch
+DEBUG util.py:461:  pcre2-syntax-10.45-1.eln146.noarch
+DEBUG util.py:461:  ncurses-base-6.5-5.20250125.eln145.noarch
+DEBUG util.py:461:  glibc-minimal-langpack-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  ncurses-libs-6.5-5.20250125.eln145.aarch64
+DEBUG util.py:461:  glibc-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  bash-5.2.37-3.eln146.aarch64
+DEBUG util.py:461:  glibc-common-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  glibc-gconv-extra-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  zlib-ng-compat-2.2.4-2.eln146.aarch64
+DEBUG util.py:461:  bzip2-libs-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  xz-libs-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libuuid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libblkid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  gmp-6.3.0-3.eln146.aarch64
+DEBUG util.py:461:  readline-8.2-13.eln146.aarch64
+DEBUG util.py:461:  popt-1.19-8.eln145.aarch64
+DEBUG util.py:461:  libxcrypt-4.4.38-6.eln146.aarch64
+DEBUG util.py:461:  libstdc++-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libzstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  elfutils-libelf-0.192-8.eln145.aarch64
+DEBUG util.py:461:  libattr-2.5.2-5.eln145.aarch64
+DEBUG util.py:461:  libacl-2.3.2-3.eln145.aarch64
+DEBUG util.py:461:  dwz-0.15-9.eln145.aarch64
+DEBUG util.py:461:  mpfr-4.2.1-6.eln145.aarch64
+DEBUG util.py:461:  gawk-5.3.1-1.eln145.aarch64
+DEBUG util.py:461:  unzip-6.0-66.eln145.aarch64
+DEBUG util.py:461:  file-libs-5.46-1.eln145.aarch64
+DEBUG util.py:461:  file-5.46-1.eln145.aarch64
+DEBUG util.py:461:  crypto-policies-20250214-1.gitfd9b9b9.eln146.noarch
+DEBUG util.py:461:  pcre2-10.45-1.eln146.aarch64
+DEBUG util.py:461:  grep-3.11-10.eln145.aarch64
+DEBUG util.py:461:  xz-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libeconf-0.7.6-1.eln146.aarch64
+DEBUG util.py:461:  libcap-ng-0.8.5-4.eln145.aarch64
+DEBUG util.py:461:  audit-libs-4.0.3-2.eln145.aarch64
+DEBUG util.py:461:  pam-libs-1.7.0-4.eln145.aarch64
+DEBUG util.py:461:  libcap-2.73-2.eln145.aarch64
+DEBUG util.py:461:  systemd-libs-257.4-1.eln146.aarch64
+DEBUG util.py:461:  libsmartcols-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libsepol-3.8-1.eln145.aarch64
+DEBUG util.py:461:  libselinux-3.8-1.eln145.aarch64
+DEBUG util.py:461:  findutils-4.10.0-5.eln145.aarch64
+DEBUG util.py:461:  sed-4.9-4.eln145.aarch64
+DEBUG util.py:461:  libmount-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  alternatives-1.32-1.eln146.aarch64
+DEBUG util.py:461:  lz4-libs-1.10.0-2.eln145.aarch64
+DEBUG util.py:461:  lua-libs-5.4.7-3.eln146.aarch64
+DEBUG util.py:461:  libffi-3.4.7-2.eln146.aarch64
+DEBUG util.py:461:  libtasn1-4.20.0-1.eln146.aarch64
+DEBUG util.py:461:  p11-kit-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  libunistring-1.1-9.eln145.aarch64
+DEBUG util.py:461:  libidn2-2.3.8-1.eln146.aarch64
+DEBUG util.py:461:  libpsl-0.21.5-5.eln145.aarch64
+DEBUG util.py:461:  p11-kit-trust-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  zstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  util-linux-core-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  tar-1.35-5.eln145.aarch64
+DEBUG util.py:461:  libsemanage-3.8-1.eln145.aarch64
+DEBUG util.py:461:  shadow-utils-4.17.0-4.eln145.aarch64
+DEBUG util.py:461:  systemd-standalone-sysusers-257.4-1.eln146.aarch64
+DEBUG util.py:461:  zip-3.0-43.eln145.aarch64
+DEBUG util.py:461:  libfdisk-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libxml2-2.12.10-1.eln146.aarch64
+DEBUG util.py:461:  bzip2-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  ed-1.21-2.eln145.aarch64
+DEBUG util.py:461:  patch-2.7.6-26.eln145.aarch64
+DEBUG util.py:461:  filesystem-srpm-macros-3.18-38.eln146.noarch
+DEBUG util.py:461:  elfutils-default-yama-scope-0.192-8.eln145.noarch
+DEBUG util.py:461:  elfutils-libs-0.192-8.eln145.aarch64
+DEBUG util.py:461:  cpio-2.15-4.eln146.aarch64
+DEBUG util.py:461:  diffutils-3.10-9.eln145.aarch64
+DEBUG util.py:461:  jansson-2.14-2.eln145.aarch64
+DEBUG util.py:461:  libgomp-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  sqlite-libs-3.49.0-1.eln146.aarch64
+DEBUG util.py:461:  json-c-0.18-2.eln145.aarch64
+DEBUG util.py:461:  libpkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-pkg-config-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  libbrotli-1.1.0-6.eln145.aarch64
+DEBUG util.py:461:  libnghttp2-1.65.0-1.eln146.aarch64
+DEBUG util.py:461:  keyutils-libs-1.6.3-5.eln145.aarch64
+DEBUG util.py:461:  libcom_err-1.47.2-3.eln145.aarch64
+DEBUG util.py:461:  libverto-0.3.2-10.eln145.aarch64
+DEBUG util.py:461:  libtool-ltdl-2.5.4-4.eln145.aarch64
+DEBUG util.py:461:  gdbm-libs-1.23-9.eln145.aarch64
+DEBUG util.py:461:  cyrus-sasl-lib-2.1.28-30.eln145.aarch64
+DEBUG util.py:461:  rust-toolset-srpm-macros-1.85.0-5.eln146.noarch
+DEBUG util.py:461:  qt6-srpm-macros-6.8.2-2.eln146.noarch
+DEBUG util.py:461:  perl-srpm-macros-1-57.eln145.noarch
+DEBUG util.py:461:  package-notes-srpm-macros-0.5-13.eln145.noarch
+DEBUG util.py:461:  openblas-srpm-macros-2-19.eln145.noarch
+DEBUG util.py:461:  ocaml-srpm-macros-10-4.eln145.noarch
+DEBUG util.py:461:  kernel-srpm-macros-1.0-25.eln145.noarch
+DEBUG util.py:461:  coreutils-common-9.6-2.eln146.aarch64
+DEBUG util.py:461:  openssl-libs-3.2.4-3.eln146.aarch64
+DEBUG util.py:461:  coreutils-9.6-2.eln146.aarch64
+DEBUG util.py:461:  ca-certificates-2024.2.69_v8.0.401-5.eln145.noarch
+DEBUG util.py:461:  libarchive-3.7.7-4.eln146.aarch64
+DEBUG util.py:461:  krb5-libs-1.21.3-5.eln145.aarch64
+DEBUG util.py:461:  libssh-0.11.1-4.eln145.aarch64
+DEBUG util.py:461:  gzip-1.13-3.eln145.aarch64
+DEBUG util.py:461:  rpm-sequoia-1.7.0-2.eln146.aarch64
+DEBUG util.py:461:  rpm-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  rpm-build-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  libevent-2.1.12-15.eln145.aarch64
+DEBUG util.py:461:  openldap-2.6.9-3.eln145.aarch64
+DEBUG util.py:461:  libcurl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  elfutils-debuginfod-client-0.192-8.eln145.aarch64
+DEBUG util.py:461:  binutils-2.44-3.eln146.aarch64
+DEBUG util.py:461:  elfutils-0.192-8.eln145.aarch64
+DEBUG util.py:461:  gdb-minimal-16.2-1.eln146.aarch64
+DEBUG util.py:461:  debugedit-5.1-5.eln146.aarch64
+DEBUG util.py:461:  curl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  rpm-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  efi-srpm-macros-6-3.eln146.noarch
+DEBUG util.py:461:  lua-srpm-macros-1-15.eln145.noarch
+DEBUG util.py:461:  fonts-srpm-macros-2.0.5-21.eln145.noarch
+DEBUG util.py:461:  forge-srpm-macros-0.4.0-2.eln145.noarch
+DEBUG util.py:461:  go-srpm-macros-3.6.0-1.eln144.noarch
+DEBUG util.py:461:  python-srpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  redhat-rpm-config-342-2.eln145.noarch
+DEBUG util.py:461:  rpm-build-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  pyproject-srpm-macros-1.17.0-1.eln146.noarch
+DEBUG util.py:461:  util-linux-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  which-2.23-1.eln145.aarch64
+DEBUG util.py:461:  info-7.2-3.eln145.aarch64
+DEBUG util.py:461:  python-rpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  python3-rpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  tzdata-2025a-1.eln146.noarch
+DEBUG util.py:461:  python-pip-wheel-24.3.1-2.eln145.noarch
+DEBUG util.py:461:  mpdecimal-4.0.0-2.eln146.aarch64
+DEBUG util.py:461:  expat-2.7.0-1.eln146.aarch64
+DEBUG util.py:461:  python3-libs-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  python3-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  python3-packaging-24.2-3.eln145.noarch
+DEBUG util.py:461:  python3-rpm-generators-14-12.eln145.noarch
+DEBUG util.py:461:  python3-iniconfig-1.1.1-25.eln145.noarch
+DEBUG util.py:461:  python3-pluggy-1.5.0-2.eln145.noarch
+DEBUG util.py:461:  python3-pytest-8.3.5-2.eln146.noarch
+DEBUG util.py:461:  python3-execnet-2.1.1-5.eln145.noarch
+DEBUG util.py:461:  python3-pytest-xdist-3.6.1-5.eln145.noarch
+DEBUG util.py:461:  python3-devel-3.13.2-2.eln146.aarch64
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+INFO backend.py:767:  Going to install missing dynamic buildrequires
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/proc', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/sys', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'devpts', '-o', 'gid=5,mode=0620,ptmxmode=0666,newinstance', 'devpts', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'bind', '/tmp/mock-selinux-plugin.id6ehnoj', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'private,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,private,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir
+DEBUG package_manager.py:295:  ['/usr/bin/dnf5', 'builddep', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.buildreqs.nosrc.rpm', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing']
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '99803f9173654df396cb02befec5ef5c', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--setenv=LC_MESSAGES=C.UTF-8', '--resolv-conf=off', '/usr/bin/dnf5', 'builddep', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.buildreqs.nosrc.rpm', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing', '--setopt=tsflags=nocontexts'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'LC_MESSAGES': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:459:  Updating and loading repositories:
+DEBUG util.py:459:  Repositories loaded.
+DEBUG util.py:459:  Package "util-linux-core-2.40.4-7.eln146.aarch64" is already installed.
+DEBUG util.py:459:  Package "python3-devel-3.13.2-2.eln146.aarch64" is already installed.
+DEBUG util.py:459:  Package "python3-pytest-8.3.5-2.eln146.noarch" is already installed.
+DEBUG util.py:459:  Package "python3-pytest-xdist-3.6.1-5.eln145.noarch" is already installed.
+DEBUG util.py:461:  Package               Arch   Version         Repository      Size
+DEBUG util.py:461:  Installing:
+DEBUG util.py:461:   pyproject-rpm-macros noarch 1.17.0-1.eln146 build      114.0 KiB
+DEBUG util.py:461:  Transaction Summary:
+DEBUG util.py:461:   Installing:         1 package
+DEBUG util.py:459:  Total size of inbound packages is 45 KiB. Need to download 45 KiB.
+DEBUG util.py:459:  After this operation, 114 KiB extra will be used (install 114 KiB, remove 0 B).
+DEBUG util.py:459:  [1/1] pyproject-rpm-macros-0:1.17.0-1.e 100% |   2.4 MiB/s |  44.7 KiB |  00m00s
+DEBUG util.py:459:  --------------------------------------------------------------------------------
+DEBUG util.py:459:  [1/1] Total                             100% |   2.4 MiB/s |  44.7 KiB |  00m00s
+DEBUG util.py:459:  Running transaction
+DEBUG util.py:459:  [1/3] Verify package files              100% |   0.0   B/s |   1.0   B |  00m00s
+DEBUG util.py:459:  [2/3] Prepare transaction               100% | 200.0   B/s |   1.0   B |  00m00s
+DEBUG util.py:459:  [3/3] Installing pyproject-rpm-macros-0 100% |   1.0 MiB/s | 115.9 KiB |  00m00s
+DEBUG util.py:459:  Warning: skipped OpenPGP checks for 1 package from repository: build
+DEBUG util.py:459:  Complete!
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'private,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,private,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '4f6da106ef214805bf9b8579df55e5c5', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', '/bin/rpm', '-qa', '--root', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:461:  libgcc-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libssh-config-0.11.1-4.eln145.noarch
+DEBUG util.py:461:  publicsuffix-list-dafsa-20250116-1.eln145.noarch
+DEBUG util.py:461:  fedora-release-identity-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-gpg-keys-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-common-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-repos-eln-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  setup-2.15.0-14.eln146.noarch
+DEBUG util.py:461:  filesystem-3.18-38.eln146.aarch64
+DEBUG util.py:461:  pkgconf-m4-2.3.0-2.eln145.noarch
+DEBUG util.py:461:  pcre2-syntax-10.45-1.eln146.noarch
+DEBUG util.py:461:  ncurses-base-6.5-5.20250125.eln145.noarch
+DEBUG util.py:461:  glibc-minimal-langpack-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  ncurses-libs-6.5-5.20250125.eln145.aarch64
+DEBUG util.py:461:  glibc-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  bash-5.2.37-3.eln146.aarch64
+DEBUG util.py:461:  glibc-common-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  glibc-gconv-extra-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  zlib-ng-compat-2.2.4-2.eln146.aarch64
+DEBUG util.py:461:  bzip2-libs-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  xz-libs-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libuuid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libblkid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  gmp-6.3.0-3.eln146.aarch64
+DEBUG util.py:461:  readline-8.2-13.eln146.aarch64
+DEBUG util.py:461:  popt-1.19-8.eln145.aarch64
+DEBUG util.py:461:  libxcrypt-4.4.38-6.eln146.aarch64
+DEBUG util.py:461:  libstdc++-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libzstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  elfutils-libelf-0.192-8.eln145.aarch64
+DEBUG util.py:461:  libattr-2.5.2-5.eln145.aarch64
+DEBUG util.py:461:  libacl-2.3.2-3.eln145.aarch64
+DEBUG util.py:461:  dwz-0.15-9.eln145.aarch64
+DEBUG util.py:461:  mpfr-4.2.1-6.eln145.aarch64
+DEBUG util.py:461:  gawk-5.3.1-1.eln145.aarch64
+DEBUG util.py:461:  unzip-6.0-66.eln145.aarch64
+DEBUG util.py:461:  file-libs-5.46-1.eln145.aarch64
+DEBUG util.py:461:  file-5.46-1.eln145.aarch64
+DEBUG util.py:461:  crypto-policies-20250214-1.gitfd9b9b9.eln146.noarch
+DEBUG util.py:461:  pcre2-10.45-1.eln146.aarch64
+DEBUG util.py:461:  grep-3.11-10.eln145.aarch64
+DEBUG util.py:461:  xz-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libeconf-0.7.6-1.eln146.aarch64
+DEBUG util.py:461:  libcap-ng-0.8.5-4.eln145.aarch64
+DEBUG util.py:461:  audit-libs-4.0.3-2.eln145.aarch64
+DEBUG util.py:461:  pam-libs-1.7.0-4.eln145.aarch64
+DEBUG util.py:461:  libcap-2.73-2.eln145.aarch64
+DEBUG util.py:461:  systemd-libs-257.4-1.eln146.aarch64
+DEBUG util.py:461:  libsmartcols-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libsepol-3.8-1.eln145.aarch64
+DEBUG util.py:461:  libselinux-3.8-1.eln145.aarch64
+DEBUG util.py:461:  findutils-4.10.0-5.eln145.aarch64
+DEBUG util.py:461:  sed-4.9-4.eln145.aarch64
+DEBUG util.py:461:  libmount-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  alternatives-1.32-1.eln146.aarch64
+DEBUG util.py:461:  lz4-libs-1.10.0-2.eln145.aarch64
+DEBUG util.py:461:  lua-libs-5.4.7-3.eln146.aarch64
+DEBUG util.py:461:  libffi-3.4.7-2.eln146.aarch64
+DEBUG util.py:461:  libtasn1-4.20.0-1.eln146.aarch64
+DEBUG util.py:461:  p11-kit-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  libunistring-1.1-9.eln145.aarch64
+DEBUG util.py:461:  libidn2-2.3.8-1.eln146.aarch64
+DEBUG util.py:461:  libpsl-0.21.5-5.eln145.aarch64
+DEBUG util.py:461:  p11-kit-trust-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  zstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  util-linux-core-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  tar-1.35-5.eln145.aarch64
+DEBUG util.py:461:  libsemanage-3.8-1.eln145.aarch64
+DEBUG util.py:461:  shadow-utils-4.17.0-4.eln145.aarch64
+DEBUG util.py:461:  systemd-standalone-sysusers-257.4-1.eln146.aarch64
+DEBUG util.py:461:  zip-3.0-43.eln145.aarch64
+DEBUG util.py:461:  libfdisk-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libxml2-2.12.10-1.eln146.aarch64
+DEBUG util.py:461:  bzip2-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  ed-1.21-2.eln145.aarch64
+DEBUG util.py:461:  patch-2.7.6-26.eln145.aarch64
+DEBUG util.py:461:  filesystem-srpm-macros-3.18-38.eln146.noarch
+DEBUG util.py:461:  elfutils-default-yama-scope-0.192-8.eln145.noarch
+DEBUG util.py:461:  elfutils-libs-0.192-8.eln145.aarch64
+DEBUG util.py:461:  cpio-2.15-4.eln146.aarch64
+DEBUG util.py:461:  diffutils-3.10-9.eln145.aarch64
+DEBUG util.py:461:  jansson-2.14-2.eln145.aarch64
+DEBUG util.py:461:  libgomp-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  sqlite-libs-3.49.0-1.eln146.aarch64
+DEBUG util.py:461:  json-c-0.18-2.eln145.aarch64
+DEBUG util.py:461:  libpkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-pkg-config-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  libbrotli-1.1.0-6.eln145.aarch64
+DEBUG util.py:461:  libnghttp2-1.65.0-1.eln146.aarch64
+DEBUG util.py:461:  keyutils-libs-1.6.3-5.eln145.aarch64
+DEBUG util.py:461:  libcom_err-1.47.2-3.eln145.aarch64
+DEBUG util.py:461:  libverto-0.3.2-10.eln145.aarch64
+DEBUG util.py:461:  libtool-ltdl-2.5.4-4.eln145.aarch64
+DEBUG util.py:461:  gdbm-libs-1.23-9.eln145.aarch64
+DEBUG util.py:461:  cyrus-sasl-lib-2.1.28-30.eln145.aarch64
+DEBUG util.py:461:  rust-toolset-srpm-macros-1.85.0-5.eln146.noarch
+DEBUG util.py:461:  qt6-srpm-macros-6.8.2-2.eln146.noarch
+DEBUG util.py:461:  perl-srpm-macros-1-57.eln145.noarch
+DEBUG util.py:461:  package-notes-srpm-macros-0.5-13.eln145.noarch
+DEBUG util.py:461:  openblas-srpm-macros-2-19.eln145.noarch
+DEBUG util.py:461:  ocaml-srpm-macros-10-4.eln145.noarch
+DEBUG util.py:461:  kernel-srpm-macros-1.0-25.eln145.noarch
+DEBUG util.py:461:  coreutils-common-9.6-2.eln146.aarch64
+DEBUG util.py:461:  openssl-libs-3.2.4-3.eln146.aarch64
+DEBUG util.py:461:  coreutils-9.6-2.eln146.aarch64
+DEBUG util.py:461:  ca-certificates-2024.2.69_v8.0.401-5.eln145.noarch
+DEBUG util.py:461:  libarchive-3.7.7-4.eln146.aarch64
+DEBUG util.py:461:  krb5-libs-1.21.3-5.eln145.aarch64
+DEBUG util.py:461:  libssh-0.11.1-4.eln145.aarch64
+DEBUG util.py:461:  gzip-1.13-3.eln145.aarch64
+DEBUG util.py:461:  rpm-sequoia-1.7.0-2.eln146.aarch64
+DEBUG util.py:461:  rpm-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  rpm-build-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  libevent-2.1.12-15.eln145.aarch64
+DEBUG util.py:461:  openldap-2.6.9-3.eln145.aarch64
+DEBUG util.py:461:  libcurl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  elfutils-debuginfod-client-0.192-8.eln145.aarch64
+DEBUG util.py:461:  binutils-2.44-3.eln146.aarch64
+DEBUG util.py:461:  elfutils-0.192-8.eln145.aarch64
+DEBUG util.py:461:  gdb-minimal-16.2-1.eln146.aarch64
+DEBUG util.py:461:  debugedit-5.1-5.eln146.aarch64
+DEBUG util.py:461:  curl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  rpm-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  efi-srpm-macros-6-3.eln146.noarch
+DEBUG util.py:461:  lua-srpm-macros-1-15.eln145.noarch
+DEBUG util.py:461:  fonts-srpm-macros-2.0.5-21.eln145.noarch
+DEBUG util.py:461:  forge-srpm-macros-0.4.0-2.eln145.noarch
+DEBUG util.py:461:  go-srpm-macros-3.6.0-1.eln144.noarch
+DEBUG util.py:461:  python-srpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  redhat-rpm-config-342-2.eln145.noarch
+DEBUG util.py:461:  rpm-build-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  pyproject-srpm-macros-1.17.0-1.eln146.noarch
+DEBUG util.py:461:  util-linux-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  which-2.23-1.eln145.aarch64
+DEBUG util.py:461:  info-7.2-3.eln145.aarch64
+DEBUG util.py:461:  python-rpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  python3-rpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  tzdata-2025a-1.eln146.noarch
+DEBUG util.py:461:  python-pip-wheel-24.3.1-2.eln145.noarch
+DEBUG util.py:461:  mpdecimal-4.0.0-2.eln146.aarch64
+DEBUG util.py:461:  expat-2.7.0-1.eln146.aarch64
+DEBUG util.py:461:  python3-libs-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  python3-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  python3-packaging-24.2-3.eln145.noarch
+DEBUG util.py:461:  python3-rpm-generators-14-12.eln145.noarch
+DEBUG util.py:461:  python3-iniconfig-1.1.1-25.eln145.noarch
+DEBUG util.py:461:  python3-pluggy-1.5.0-2.eln145.noarch
+DEBUG util.py:461:  python3-pytest-8.3.5-2.eln146.noarch
+DEBUG util.py:461:  python3-execnet-2.1.1-5.eln145.noarch
+DEBUG util.py:461:  python3-pytest-xdist-3.6.1-5.eln145.noarch
+DEBUG util.py:461:  python3-devel-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  pyproject-rpm-macros-1.17.0-1.eln146.noarch
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'private,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,private,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '955752a5636441a292a7a7c6565a611a', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', '/bin/rpm', '-qa', '--root', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:461:  libgcc-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libssh-config-0.11.1-4.eln145.noarch
+DEBUG util.py:461:  publicsuffix-list-dafsa-20250116-1.eln145.noarch
+DEBUG util.py:461:  fedora-release-identity-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-gpg-keys-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-common-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-repos-eln-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  setup-2.15.0-14.eln146.noarch
+DEBUG util.py:461:  filesystem-3.18-38.eln146.aarch64
+DEBUG util.py:461:  pkgconf-m4-2.3.0-2.eln145.noarch
+DEBUG util.py:461:  pcre2-syntax-10.45-1.eln146.noarch
+DEBUG util.py:461:  ncurses-base-6.5-5.20250125.eln145.noarch
+DEBUG util.py:461:  glibc-minimal-langpack-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  ncurses-libs-6.5-5.20250125.eln145.aarch64
+DEBUG util.py:461:  glibc-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  bash-5.2.37-3.eln146.aarch64
+DEBUG util.py:461:  glibc-common-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  glibc-gconv-extra-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  zlib-ng-compat-2.2.4-2.eln146.aarch64
+DEBUG util.py:461:  bzip2-libs-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  xz-libs-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libuuid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libblkid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  gmp-6.3.0-3.eln146.aarch64
+DEBUG util.py:461:  readline-8.2-13.eln146.aarch64
+DEBUG util.py:461:  popt-1.19-8.eln145.aarch64
+DEBUG util.py:461:  libxcrypt-4.4.38-6.eln146.aarch64
+DEBUG util.py:461:  libstdc++-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libzstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  elfutils-libelf-0.192-8.eln145.aarch64
+DEBUG util.py:461:  libattr-2.5.2-5.eln145.aarch64
+DEBUG util.py:461:  libacl-2.3.2-3.eln145.aarch64
+DEBUG util.py:461:  dwz-0.15-9.eln145.aarch64
+DEBUG util.py:461:  mpfr-4.2.1-6.eln145.aarch64
+DEBUG util.py:461:  gawk-5.3.1-1.eln145.aarch64
+DEBUG util.py:461:  unzip-6.0-66.eln145.aarch64
+DEBUG util.py:461:  file-libs-5.46-1.eln145.aarch64
+DEBUG util.py:461:  file-5.46-1.eln145.aarch64
+DEBUG util.py:461:  crypto-policies-20250214-1.gitfd9b9b9.eln146.noarch
+DEBUG util.py:461:  pcre2-10.45-1.eln146.aarch64
+DEBUG util.py:461:  grep-3.11-10.eln145.aarch64
+DEBUG util.py:461:  xz-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libeconf-0.7.6-1.eln146.aarch64
+DEBUG util.py:461:  libcap-ng-0.8.5-4.eln145.aarch64
+DEBUG util.py:461:  audit-libs-4.0.3-2.eln145.aarch64
+DEBUG util.py:461:  pam-libs-1.7.0-4.eln145.aarch64
+DEBUG util.py:461:  libcap-2.73-2.eln145.aarch64
+DEBUG util.py:461:  systemd-libs-257.4-1.eln146.aarch64
+DEBUG util.py:461:  libsmartcols-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libsepol-3.8-1.eln145.aarch64
+DEBUG util.py:461:  libselinux-3.8-1.eln145.aarch64
+DEBUG util.py:461:  findutils-4.10.0-5.eln145.aarch64
+DEBUG util.py:461:  sed-4.9-4.eln145.aarch64
+DEBUG util.py:461:  libmount-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  alternatives-1.32-1.eln146.aarch64
+DEBUG util.py:461:  lz4-libs-1.10.0-2.eln145.aarch64
+DEBUG util.py:461:  lua-libs-5.4.7-3.eln146.aarch64
+DEBUG util.py:461:  libffi-3.4.7-2.eln146.aarch64
+DEBUG util.py:461:  libtasn1-4.20.0-1.eln146.aarch64
+DEBUG util.py:461:  p11-kit-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  libunistring-1.1-9.eln145.aarch64
+DEBUG util.py:461:  libidn2-2.3.8-1.eln146.aarch64
+DEBUG util.py:461:  libpsl-0.21.5-5.eln145.aarch64
+DEBUG util.py:461:  p11-kit-trust-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  zstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  util-linux-core-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  tar-1.35-5.eln145.aarch64
+DEBUG util.py:461:  libsemanage-3.8-1.eln145.aarch64
+DEBUG util.py:461:  shadow-utils-4.17.0-4.eln145.aarch64
+DEBUG util.py:461:  systemd-standalone-sysusers-257.4-1.eln146.aarch64
+DEBUG util.py:461:  zip-3.0-43.eln145.aarch64
+DEBUG util.py:461:  libfdisk-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libxml2-2.12.10-1.eln146.aarch64
+DEBUG util.py:461:  bzip2-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  ed-1.21-2.eln145.aarch64
+DEBUG util.py:461:  patch-2.7.6-26.eln145.aarch64
+DEBUG util.py:461:  filesystem-srpm-macros-3.18-38.eln146.noarch
+DEBUG util.py:461:  elfutils-default-yama-scope-0.192-8.eln145.noarch
+DEBUG util.py:461:  elfutils-libs-0.192-8.eln145.aarch64
+DEBUG util.py:461:  cpio-2.15-4.eln146.aarch64
+DEBUG util.py:461:  diffutils-3.10-9.eln145.aarch64
+DEBUG util.py:461:  jansson-2.14-2.eln145.aarch64
+DEBUG util.py:461:  libgomp-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  sqlite-libs-3.49.0-1.eln146.aarch64
+DEBUG util.py:461:  json-c-0.18-2.eln145.aarch64
+DEBUG util.py:461:  libpkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-pkg-config-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  libbrotli-1.1.0-6.eln145.aarch64
+DEBUG util.py:461:  libnghttp2-1.65.0-1.eln146.aarch64
+DEBUG util.py:461:  keyutils-libs-1.6.3-5.eln145.aarch64
+DEBUG util.py:461:  libcom_err-1.47.2-3.eln145.aarch64
+DEBUG util.py:461:  libverto-0.3.2-10.eln145.aarch64
+DEBUG util.py:461:  libtool-ltdl-2.5.4-4.eln145.aarch64
+DEBUG util.py:461:  gdbm-libs-1.23-9.eln145.aarch64
+DEBUG util.py:461:  cyrus-sasl-lib-2.1.28-30.eln145.aarch64
+DEBUG util.py:461:  rust-toolset-srpm-macros-1.85.0-5.eln146.noarch
+DEBUG util.py:461:  qt6-srpm-macros-6.8.2-2.eln146.noarch
+DEBUG util.py:461:  perl-srpm-macros-1-57.eln145.noarch
+DEBUG util.py:461:  package-notes-srpm-macros-0.5-13.eln145.noarch
+DEBUG util.py:461:  openblas-srpm-macros-2-19.eln145.noarch
+DEBUG util.py:461:  ocaml-srpm-macros-10-4.eln145.noarch
+DEBUG util.py:461:  kernel-srpm-macros-1.0-25.eln145.noarch
+DEBUG util.py:461:  coreutils-common-9.6-2.eln146.aarch64
+DEBUG util.py:461:  openssl-libs-3.2.4-3.eln146.aarch64
+DEBUG util.py:461:  coreutils-9.6-2.eln146.aarch64
+DEBUG util.py:461:  ca-certificates-2024.2.69_v8.0.401-5.eln145.noarch
+DEBUG util.py:461:  libarchive-3.7.7-4.eln146.aarch64
+DEBUG util.py:461:  krb5-libs-1.21.3-5.eln145.aarch64
+DEBUG util.py:461:  libssh-0.11.1-4.eln145.aarch64
+DEBUG util.py:461:  gzip-1.13-3.eln145.aarch64
+DEBUG util.py:461:  rpm-sequoia-1.7.0-2.eln146.aarch64
+DEBUG util.py:461:  rpm-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  rpm-build-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  libevent-2.1.12-15.eln145.aarch64
+DEBUG util.py:461:  openldap-2.6.9-3.eln145.aarch64
+DEBUG util.py:461:  libcurl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  elfutils-debuginfod-client-0.192-8.eln145.aarch64
+DEBUG util.py:461:  binutils-2.44-3.eln146.aarch64
+DEBUG util.py:461:  elfutils-0.192-8.eln145.aarch64
+DEBUG util.py:461:  gdb-minimal-16.2-1.eln146.aarch64
+DEBUG util.py:461:  debugedit-5.1-5.eln146.aarch64
+DEBUG util.py:461:  curl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  rpm-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  efi-srpm-macros-6-3.eln146.noarch
+DEBUG util.py:461:  lua-srpm-macros-1-15.eln145.noarch
+DEBUG util.py:461:  fonts-srpm-macros-2.0.5-21.eln145.noarch
+DEBUG util.py:461:  forge-srpm-macros-0.4.0-2.eln145.noarch
+DEBUG util.py:461:  go-srpm-macros-3.6.0-1.eln144.noarch
+DEBUG util.py:461:  python-srpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  redhat-rpm-config-342-2.eln145.noarch
+DEBUG util.py:461:  rpm-build-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  pyproject-srpm-macros-1.17.0-1.eln146.noarch
+DEBUG util.py:461:  util-linux-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  which-2.23-1.eln145.aarch64
+DEBUG util.py:461:  info-7.2-3.eln145.aarch64
+DEBUG util.py:461:  python-rpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  python3-rpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  tzdata-2025a-1.eln146.noarch
+DEBUG util.py:461:  python-pip-wheel-24.3.1-2.eln145.noarch
+DEBUG util.py:461:  mpdecimal-4.0.0-2.eln146.aarch64
+DEBUG util.py:461:  expat-2.7.0-1.eln146.aarch64
+DEBUG util.py:461:  python3-libs-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  python3-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  python3-packaging-24.2-3.eln145.noarch
+DEBUG util.py:461:  python3-rpm-generators-14-12.eln145.noarch
+DEBUG util.py:461:  python3-iniconfig-1.1.1-25.eln145.noarch
+DEBUG util.py:461:  python3-pluggy-1.5.0-2.eln145.noarch
+DEBUG util.py:461:  python3-pytest-8.3.5-2.eln146.noarch
+DEBUG util.py:461:  python3-execnet-2.1.1-5.eln145.noarch
+DEBUG util.py:461:  python3-pytest-xdist-3.6.1-5.eln145.noarch
+DEBUG util.py:461:  python3-devel-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  pyproject-rpm-macros-1.17.0-1.eln146.noarch
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+INFO backend.py:767:  Going to install missing dynamic buildrequires
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/proc', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/sys', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'devpts', '-o', 'gid=5,mode=0620,ptmxmode=0666,newinstance', 'devpts', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'bind', '/tmp/mock-selinux-plugin.id6ehnoj', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'private,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,private,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir
+DEBUG package_manager.py:295:  ['/usr/bin/dnf5', 'builddep', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.buildreqs.nosrc.rpm', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing']
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '36b3ee963f33435481149fa29b5b263c', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--setenv=LC_MESSAGES=C.UTF-8', '--resolv-conf=off', '/usr/bin/dnf5', 'builddep', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.buildreqs.nosrc.rpm', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing', '--setopt=tsflags=nocontexts'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'LC_MESSAGES': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:459:  Updating and loading repositories:
+DEBUG util.py:459:  Repositories loaded.
+DEBUG util.py:459:  Package "util-linux-core-2.40.4-7.eln146.aarch64" is already installed.
+DEBUG util.py:459:  Package "pyproject-rpm-macros-1.17.0-1.eln146.noarch" is already installed.
+DEBUG util.py:459:  Package "python3-devel-3.13.2-2.eln146.aarch64" is already installed.
+DEBUG util.py:459:  Package "python3-packaging-24.2-3.eln145.noarch" is already installed.
+DEBUG util.py:459:  Package "python3-pytest-8.3.5-2.eln146.noarch" is already installed.
+DEBUG util.py:459:  Package "python3-pytest-xdist-3.6.1-5.eln145.noarch" is already installed.
+DEBUG util.py:461:  Package             Arch   Version         Repository      Size
+DEBUG util.py:461:  Installing:
+DEBUG util.py:461:   python3-pip        noarch 24.3.1-2.eln145 build       11.4 MiB
+DEBUG util.py:461:   python3-setuptools noarch 74.1.3-5.eln145 build        8.4 MiB
+DEBUG util.py:461:  Transaction Summary:
+DEBUG util.py:461:   Installing:         2 packages
+DEBUG util.py:459:  Total size of inbound packages is 4 MiB. Need to download 4 MiB.
+DEBUG util.py:459:  After this operation, 20 MiB extra will be used (install 20 MiB, remove 0 B).
+DEBUG util.py:459:  [1/2] python3-setuptools-0:74.1.3-5.eln 100% |  47.7 MiB/s |   1.8 MiB |  00m00s
+DEBUG util.py:459:  [2/2] python3-pip-0:24.3.1-2.eln145.noa 100% |  55.1 MiB/s |   2.5 MiB |  00m00s
+DEBUG util.py:459:  --------------------------------------------------------------------------------
+DEBUG util.py:459:  [2/2] Total                             100% |  93.3 MiB/s |   4.3 MiB |  00m00s
+DEBUG util.py:459:  Running transaction
+DEBUG util.py:459:  [1/4] Verify package files              100% | 133.0   B/s |   2.0   B |  00m00s
+DEBUG util.py:459:  [2/4] Prepare transaction               100% |  68.0   B/s |   2.0   B |  00m00s
+DEBUG util.py:459:  [3/4] Installing python3-setuptools-0:7 100% |  65.2 MiB/s |   8.6 MiB |  00m00s
+DEBUG util.py:459:  [4/4] Installing python3-pip-0:24.3.1-2 100% |  24.3 MiB/s |  11.6 MiB |  00m00s
+DEBUG util.py:459:  Warning: skipped OpenPGP checks for 2 packages from repository: build
+DEBUG util.py:459:  Complete!
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'private,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,private,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '28d512a5da9246d0ace8ae5472ca9432', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', '/bin/rpm', '-qa', '--root', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:461:  libgcc-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libssh-config-0.11.1-4.eln145.noarch
+DEBUG util.py:461:  publicsuffix-list-dafsa-20250116-1.eln145.noarch
+DEBUG util.py:461:  fedora-release-identity-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-gpg-keys-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-common-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-repos-eln-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  setup-2.15.0-14.eln146.noarch
+DEBUG util.py:461:  filesystem-3.18-38.eln146.aarch64
+DEBUG util.py:461:  pkgconf-m4-2.3.0-2.eln145.noarch
+DEBUG util.py:461:  pcre2-syntax-10.45-1.eln146.noarch
+DEBUG util.py:461:  ncurses-base-6.5-5.20250125.eln145.noarch
+DEBUG util.py:461:  glibc-minimal-langpack-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  ncurses-libs-6.5-5.20250125.eln145.aarch64
+DEBUG util.py:461:  glibc-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  bash-5.2.37-3.eln146.aarch64
+DEBUG util.py:461:  glibc-common-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  glibc-gconv-extra-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  zlib-ng-compat-2.2.4-2.eln146.aarch64
+DEBUG util.py:461:  bzip2-libs-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  xz-libs-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libuuid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libblkid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  gmp-6.3.0-3.eln146.aarch64
+DEBUG util.py:461:  readline-8.2-13.eln146.aarch64
+DEBUG util.py:461:  popt-1.19-8.eln145.aarch64
+DEBUG util.py:461:  libxcrypt-4.4.38-6.eln146.aarch64
+DEBUG util.py:461:  libstdc++-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libzstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  elfutils-libelf-0.192-8.eln145.aarch64
+DEBUG util.py:461:  libattr-2.5.2-5.eln145.aarch64
+DEBUG util.py:461:  libacl-2.3.2-3.eln145.aarch64
+DEBUG util.py:461:  dwz-0.15-9.eln145.aarch64
+DEBUG util.py:461:  mpfr-4.2.1-6.eln145.aarch64
+DEBUG util.py:461:  gawk-5.3.1-1.eln145.aarch64
+DEBUG util.py:461:  unzip-6.0-66.eln145.aarch64
+DEBUG util.py:461:  file-libs-5.46-1.eln145.aarch64
+DEBUG util.py:461:  file-5.46-1.eln145.aarch64
+DEBUG util.py:461:  crypto-policies-20250214-1.gitfd9b9b9.eln146.noarch
+DEBUG util.py:461:  pcre2-10.45-1.eln146.aarch64
+DEBUG util.py:461:  grep-3.11-10.eln145.aarch64
+DEBUG util.py:461:  xz-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libeconf-0.7.6-1.eln146.aarch64
+DEBUG util.py:461:  libcap-ng-0.8.5-4.eln145.aarch64
+DEBUG util.py:461:  audit-libs-4.0.3-2.eln145.aarch64
+DEBUG util.py:461:  pam-libs-1.7.0-4.eln145.aarch64
+DEBUG util.py:461:  libcap-2.73-2.eln145.aarch64
+DEBUG util.py:461:  systemd-libs-257.4-1.eln146.aarch64
+DEBUG util.py:461:  libsmartcols-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libsepol-3.8-1.eln145.aarch64
+DEBUG util.py:461:  libselinux-3.8-1.eln145.aarch64
+DEBUG util.py:461:  findutils-4.10.0-5.eln145.aarch64
+DEBUG util.py:461:  sed-4.9-4.eln145.aarch64
+DEBUG util.py:461:  libmount-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  alternatives-1.32-1.eln146.aarch64
+DEBUG util.py:461:  lz4-libs-1.10.0-2.eln145.aarch64
+DEBUG util.py:461:  lua-libs-5.4.7-3.eln146.aarch64
+DEBUG util.py:461:  libffi-3.4.7-2.eln146.aarch64
+DEBUG util.py:461:  libtasn1-4.20.0-1.eln146.aarch64
+DEBUG util.py:461:  p11-kit-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  libunistring-1.1-9.eln145.aarch64
+DEBUG util.py:461:  libidn2-2.3.8-1.eln146.aarch64
+DEBUG util.py:461:  libpsl-0.21.5-5.eln145.aarch64
+DEBUG util.py:461:  p11-kit-trust-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  zstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  util-linux-core-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  tar-1.35-5.eln145.aarch64
+DEBUG util.py:461:  libsemanage-3.8-1.eln145.aarch64
+DEBUG util.py:461:  shadow-utils-4.17.0-4.eln145.aarch64
+DEBUG util.py:461:  systemd-standalone-sysusers-257.4-1.eln146.aarch64
+DEBUG util.py:461:  zip-3.0-43.eln145.aarch64
+DEBUG util.py:461:  libfdisk-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libxml2-2.12.10-1.eln146.aarch64
+DEBUG util.py:461:  bzip2-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  ed-1.21-2.eln145.aarch64
+DEBUG util.py:461:  patch-2.7.6-26.eln145.aarch64
+DEBUG util.py:461:  filesystem-srpm-macros-3.18-38.eln146.noarch
+DEBUG util.py:461:  elfutils-default-yama-scope-0.192-8.eln145.noarch
+DEBUG util.py:461:  elfutils-libs-0.192-8.eln145.aarch64
+DEBUG util.py:461:  cpio-2.15-4.eln146.aarch64
+DEBUG util.py:461:  diffutils-3.10-9.eln145.aarch64
+DEBUG util.py:461:  jansson-2.14-2.eln145.aarch64
+DEBUG util.py:461:  libgomp-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  sqlite-libs-3.49.0-1.eln146.aarch64
+DEBUG util.py:461:  json-c-0.18-2.eln145.aarch64
+DEBUG util.py:461:  libpkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-pkg-config-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  libbrotli-1.1.0-6.eln145.aarch64
+DEBUG util.py:461:  libnghttp2-1.65.0-1.eln146.aarch64
+DEBUG util.py:461:  keyutils-libs-1.6.3-5.eln145.aarch64
+DEBUG util.py:461:  libcom_err-1.47.2-3.eln145.aarch64
+DEBUG util.py:461:  libverto-0.3.2-10.eln145.aarch64
+DEBUG util.py:461:  libtool-ltdl-2.5.4-4.eln145.aarch64
+DEBUG util.py:461:  gdbm-libs-1.23-9.eln145.aarch64
+DEBUG util.py:461:  cyrus-sasl-lib-2.1.28-30.eln145.aarch64
+DEBUG util.py:461:  rust-toolset-srpm-macros-1.85.0-5.eln146.noarch
+DEBUG util.py:461:  qt6-srpm-macros-6.8.2-2.eln146.noarch
+DEBUG util.py:461:  perl-srpm-macros-1-57.eln145.noarch
+DEBUG util.py:461:  package-notes-srpm-macros-0.5-13.eln145.noarch
+DEBUG util.py:461:  openblas-srpm-macros-2-19.eln145.noarch
+DEBUG util.py:461:  ocaml-srpm-macros-10-4.eln145.noarch
+DEBUG util.py:461:  kernel-srpm-macros-1.0-25.eln145.noarch
+DEBUG util.py:461:  coreutils-common-9.6-2.eln146.aarch64
+DEBUG util.py:461:  openssl-libs-3.2.4-3.eln146.aarch64
+DEBUG util.py:461:  coreutils-9.6-2.eln146.aarch64
+DEBUG util.py:461:  ca-certificates-2024.2.69_v8.0.401-5.eln145.noarch
+DEBUG util.py:461:  libarchive-3.7.7-4.eln146.aarch64
+DEBUG util.py:461:  krb5-libs-1.21.3-5.eln145.aarch64
+DEBUG util.py:461:  libssh-0.11.1-4.eln145.aarch64
+DEBUG util.py:461:  gzip-1.13-3.eln145.aarch64
+DEBUG util.py:461:  rpm-sequoia-1.7.0-2.eln146.aarch64
+DEBUG util.py:461:  rpm-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  rpm-build-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  libevent-2.1.12-15.eln145.aarch64
+DEBUG util.py:461:  openldap-2.6.9-3.eln145.aarch64
+DEBUG util.py:461:  libcurl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  elfutils-debuginfod-client-0.192-8.eln145.aarch64
+DEBUG util.py:461:  binutils-2.44-3.eln146.aarch64
+DEBUG util.py:461:  elfutils-0.192-8.eln145.aarch64
+DEBUG util.py:461:  gdb-minimal-16.2-1.eln146.aarch64
+DEBUG util.py:461:  debugedit-5.1-5.eln146.aarch64
+DEBUG util.py:461:  curl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  rpm-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  efi-srpm-macros-6-3.eln146.noarch
+DEBUG util.py:461:  lua-srpm-macros-1-15.eln145.noarch
+DEBUG util.py:461:  fonts-srpm-macros-2.0.5-21.eln145.noarch
+DEBUG util.py:461:  forge-srpm-macros-0.4.0-2.eln145.noarch
+DEBUG util.py:461:  go-srpm-macros-3.6.0-1.eln144.noarch
+DEBUG util.py:461:  python-srpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  redhat-rpm-config-342-2.eln145.noarch
+DEBUG util.py:461:  rpm-build-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  pyproject-srpm-macros-1.17.0-1.eln146.noarch
+DEBUG util.py:461:  util-linux-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  which-2.23-1.eln145.aarch64
+DEBUG util.py:461:  info-7.2-3.eln145.aarch64
+DEBUG util.py:461:  python-rpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  python3-rpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  tzdata-2025a-1.eln146.noarch
+DEBUG util.py:461:  python-pip-wheel-24.3.1-2.eln145.noarch
+DEBUG util.py:461:  mpdecimal-4.0.0-2.eln146.aarch64
+DEBUG util.py:461:  expat-2.7.0-1.eln146.aarch64
+DEBUG util.py:461:  python3-libs-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  python3-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  python3-packaging-24.2-3.eln145.noarch
+DEBUG util.py:461:  python3-rpm-generators-14-12.eln145.noarch
+DEBUG util.py:461:  python3-iniconfig-1.1.1-25.eln145.noarch
+DEBUG util.py:461:  python3-pluggy-1.5.0-2.eln145.noarch
+DEBUG util.py:461:  python3-pytest-8.3.5-2.eln146.noarch
+DEBUG util.py:461:  python3-execnet-2.1.1-5.eln145.noarch
+DEBUG util.py:461:  python3-pytest-xdist-3.6.1-5.eln145.noarch
+DEBUG util.py:461:  python3-devel-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  pyproject-rpm-macros-1.17.0-1.eln146.noarch
+DEBUG util.py:461:  python3-setuptools-74.1.3-5.eln145.noarch
+DEBUG util.py:461:  python3-pip-24.3.1-2.eln145.noarch
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'private,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,private,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', '880020bf112f499990e970d2f0236204', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/builddir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--resolv-conf=off', '/bin/rpm', '-qa', '--root', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:461:  libgcc-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libssh-config-0.11.1-4.eln145.noarch
+DEBUG util.py:461:  publicsuffix-list-dafsa-20250116-1.eln145.noarch
+DEBUG util.py:461:  fedora-release-identity-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-gpg-keys-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-common-43-0.7.eln147.noarch
+DEBUG util.py:461:  fedora-repos-eln-43-0.1.eln146.noarch
+DEBUG util.py:461:  fedora-release-eln-43-0.7.eln147.noarch
+DEBUG util.py:461:  setup-2.15.0-14.eln146.noarch
+DEBUG util.py:461:  filesystem-3.18-38.eln146.aarch64
+DEBUG util.py:461:  pkgconf-m4-2.3.0-2.eln145.noarch
+DEBUG util.py:461:  pcre2-syntax-10.45-1.eln146.noarch
+DEBUG util.py:461:  ncurses-base-6.5-5.20250125.eln145.noarch
+DEBUG util.py:461:  glibc-minimal-langpack-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  ncurses-libs-6.5-5.20250125.eln145.aarch64
+DEBUG util.py:461:  glibc-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  bash-5.2.37-3.eln146.aarch64
+DEBUG util.py:461:  glibc-common-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  glibc-gconv-extra-2.41.9000-2.eln146.aarch64
+DEBUG util.py:461:  zlib-ng-compat-2.2.4-2.eln146.aarch64
+DEBUG util.py:461:  bzip2-libs-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  xz-libs-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libuuid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libblkid-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  gmp-6.3.0-3.eln146.aarch64
+DEBUG util.py:461:  readline-8.2-13.eln146.aarch64
+DEBUG util.py:461:  popt-1.19-8.eln145.aarch64
+DEBUG util.py:461:  libxcrypt-4.4.38-6.eln146.aarch64
+DEBUG util.py:461:  libstdc++-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  libzstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  elfutils-libelf-0.192-8.eln145.aarch64
+DEBUG util.py:461:  libattr-2.5.2-5.eln145.aarch64
+DEBUG util.py:461:  libacl-2.3.2-3.eln145.aarch64
+DEBUG util.py:461:  dwz-0.15-9.eln145.aarch64
+DEBUG util.py:461:  mpfr-4.2.1-6.eln145.aarch64
+DEBUG util.py:461:  gawk-5.3.1-1.eln145.aarch64
+DEBUG util.py:461:  unzip-6.0-66.eln145.aarch64
+DEBUG util.py:461:  file-libs-5.46-1.eln145.aarch64
+DEBUG util.py:461:  file-5.46-1.eln145.aarch64
+DEBUG util.py:461:  crypto-policies-20250214-1.gitfd9b9b9.eln146.noarch
+DEBUG util.py:461:  pcre2-10.45-1.eln146.aarch64
+DEBUG util.py:461:  grep-3.11-10.eln145.aarch64
+DEBUG util.py:461:  xz-5.6.3-3.eln145.aarch64
+DEBUG util.py:461:  libeconf-0.7.6-1.eln146.aarch64
+DEBUG util.py:461:  libcap-ng-0.8.5-4.eln145.aarch64
+DEBUG util.py:461:  audit-libs-4.0.3-2.eln145.aarch64
+DEBUG util.py:461:  pam-libs-1.7.0-4.eln145.aarch64
+DEBUG util.py:461:  libcap-2.73-2.eln145.aarch64
+DEBUG util.py:461:  systemd-libs-257.4-1.eln146.aarch64
+DEBUG util.py:461:  libsmartcols-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libsepol-3.8-1.eln145.aarch64
+DEBUG util.py:461:  libselinux-3.8-1.eln145.aarch64
+DEBUG util.py:461:  findutils-4.10.0-5.eln145.aarch64
+DEBUG util.py:461:  sed-4.9-4.eln145.aarch64
+DEBUG util.py:461:  libmount-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  alternatives-1.32-1.eln146.aarch64
+DEBUG util.py:461:  lz4-libs-1.10.0-2.eln145.aarch64
+DEBUG util.py:461:  lua-libs-5.4.7-3.eln146.aarch64
+DEBUG util.py:461:  libffi-3.4.7-2.eln146.aarch64
+DEBUG util.py:461:  libtasn1-4.20.0-1.eln146.aarch64
+DEBUG util.py:461:  p11-kit-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  libunistring-1.1-9.eln145.aarch64
+DEBUG util.py:461:  libidn2-2.3.8-1.eln146.aarch64
+DEBUG util.py:461:  libpsl-0.21.5-5.eln145.aarch64
+DEBUG util.py:461:  p11-kit-trust-0.25.5-5.eln145.aarch64
+DEBUG util.py:461:  zstd-1.5.7-1.eln146.aarch64
+DEBUG util.py:461:  util-linux-core-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  tar-1.35-5.eln145.aarch64
+DEBUG util.py:461:  libsemanage-3.8-1.eln145.aarch64
+DEBUG util.py:461:  shadow-utils-4.17.0-4.eln145.aarch64
+DEBUG util.py:461:  systemd-standalone-sysusers-257.4-1.eln146.aarch64
+DEBUG util.py:461:  zip-3.0-43.eln145.aarch64
+DEBUG util.py:461:  libfdisk-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  libxml2-2.12.10-1.eln146.aarch64
+DEBUG util.py:461:  bzip2-1.0.8-20.eln145.aarch64
+DEBUG util.py:461:  ed-1.21-2.eln145.aarch64
+DEBUG util.py:461:  patch-2.7.6-26.eln145.aarch64
+DEBUG util.py:461:  filesystem-srpm-macros-3.18-38.eln146.noarch
+DEBUG util.py:461:  elfutils-default-yama-scope-0.192-8.eln145.noarch
+DEBUG util.py:461:  elfutils-libs-0.192-8.eln145.aarch64
+DEBUG util.py:461:  cpio-2.15-4.eln146.aarch64
+DEBUG util.py:461:  diffutils-3.10-9.eln145.aarch64
+DEBUG util.py:461:  jansson-2.14-2.eln145.aarch64
+DEBUG util.py:461:  libgomp-15.0.1-0.10.eln146.aarch64
+DEBUG util.py:461:  sqlite-libs-3.49.0-1.eln146.aarch64
+DEBUG util.py:461:  json-c-0.18-2.eln145.aarch64
+DEBUG util.py:461:  libpkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  pkgconf-pkg-config-2.3.0-2.eln145.aarch64
+DEBUG util.py:461:  libbrotli-1.1.0-6.eln145.aarch64
+DEBUG util.py:461:  libnghttp2-1.65.0-1.eln146.aarch64
+DEBUG util.py:461:  keyutils-libs-1.6.3-5.eln145.aarch64
+DEBUG util.py:461:  libcom_err-1.47.2-3.eln145.aarch64
+DEBUG util.py:461:  libverto-0.3.2-10.eln145.aarch64
+DEBUG util.py:461:  libtool-ltdl-2.5.4-4.eln145.aarch64
+DEBUG util.py:461:  gdbm-libs-1.23-9.eln145.aarch64
+DEBUG util.py:461:  cyrus-sasl-lib-2.1.28-30.eln145.aarch64
+DEBUG util.py:461:  rust-toolset-srpm-macros-1.85.0-5.eln146.noarch
+DEBUG util.py:461:  qt6-srpm-macros-6.8.2-2.eln146.noarch
+DEBUG util.py:461:  perl-srpm-macros-1-57.eln145.noarch
+DEBUG util.py:461:  package-notes-srpm-macros-0.5-13.eln145.noarch
+DEBUG util.py:461:  openblas-srpm-macros-2-19.eln145.noarch
+DEBUG util.py:461:  ocaml-srpm-macros-10-4.eln145.noarch
+DEBUG util.py:461:  kernel-srpm-macros-1.0-25.eln145.noarch
+DEBUG util.py:461:  coreutils-common-9.6-2.eln146.aarch64
+DEBUG util.py:461:  openssl-libs-3.2.4-3.eln146.aarch64
+DEBUG util.py:461:  coreutils-9.6-2.eln146.aarch64
+DEBUG util.py:461:  ca-certificates-2024.2.69_v8.0.401-5.eln145.noarch
+DEBUG util.py:461:  libarchive-3.7.7-4.eln146.aarch64
+DEBUG util.py:461:  krb5-libs-1.21.3-5.eln145.aarch64
+DEBUG util.py:461:  libssh-0.11.1-4.eln145.aarch64
+DEBUG util.py:461:  gzip-1.13-3.eln145.aarch64
+DEBUG util.py:461:  rpm-sequoia-1.7.0-2.eln146.aarch64
+DEBUG util.py:461:  rpm-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  rpm-build-libs-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  libevent-2.1.12-15.eln145.aarch64
+DEBUG util.py:461:  openldap-2.6.9-3.eln145.aarch64
+DEBUG util.py:461:  libcurl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  elfutils-debuginfod-client-0.192-8.eln145.aarch64
+DEBUG util.py:461:  binutils-2.44-3.eln146.aarch64
+DEBUG util.py:461:  elfutils-0.192-8.eln145.aarch64
+DEBUG util.py:461:  gdb-minimal-16.2-1.eln146.aarch64
+DEBUG util.py:461:  debugedit-5.1-5.eln146.aarch64
+DEBUG util.py:461:  curl-8.13.0~rc1-2.eln146.aarch64
+DEBUG util.py:461:  rpm-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  efi-srpm-macros-6-3.eln146.noarch
+DEBUG util.py:461:  lua-srpm-macros-1-15.eln145.noarch
+DEBUG util.py:461:  fonts-srpm-macros-2.0.5-21.eln145.noarch
+DEBUG util.py:461:  forge-srpm-macros-0.4.0-2.eln145.noarch
+DEBUG util.py:461:  go-srpm-macros-3.6.0-1.eln144.noarch
+DEBUG util.py:461:  python-srpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  redhat-rpm-config-342-2.eln145.noarch
+DEBUG util.py:461:  rpm-build-4.20.1-1.eln146.aarch64
+DEBUG util.py:461:  pyproject-srpm-macros-1.17.0-1.eln146.noarch
+DEBUG util.py:461:  util-linux-2.40.4-7.eln146.aarch64
+DEBUG util.py:461:  which-2.23-1.eln145.aarch64
+DEBUG util.py:461:  info-7.2-3.eln145.aarch64
+DEBUG util.py:461:  python-rpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  python3-rpm-macros-3.13-4.eln145.noarch
+DEBUG util.py:461:  tzdata-2025a-1.eln146.noarch
+DEBUG util.py:461:  python-pip-wheel-24.3.1-2.eln145.noarch
+DEBUG util.py:461:  mpdecimal-4.0.0-2.eln146.aarch64
+DEBUG util.py:461:  expat-2.7.0-1.eln146.aarch64
+DEBUG util.py:461:  python3-libs-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  python3-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  python3-packaging-24.2-3.eln145.noarch
+DEBUG util.py:461:  python3-rpm-generators-14-12.eln145.noarch
+DEBUG util.py:461:  python3-iniconfig-1.1.1-25.eln145.noarch
+DEBUG util.py:461:  python3-pluggy-1.5.0-2.eln145.noarch
+DEBUG util.py:461:  python3-pytest-8.3.5-2.eln146.noarch
+DEBUG util.py:461:  python3-execnet-2.1.1-5.eln145.noarch
+DEBUG util.py:461:  python3-pytest-xdist-3.6.1-5.eln145.noarch
+DEBUG util.py:461:  python3-devel-3.13.2-2.eln146.aarch64
+DEBUG util.py:461:  pyproject-rpm-macros-1.17.0-1.eln146.noarch
+DEBUG util.py:461:  python3-setuptools-74.1.3-5.eln145.noarch
+DEBUG util.py:461:  python3-pip-24.3.1-2.eln145.noarch
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+INFO backend.py:767:  Going to install missing dynamic buildrequires
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/proc', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'rprivate,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/sys', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,nodev,noexec,nosuid,readonly,rprivate,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'devpts', '-o', 'gid=5,mode=0620,ptmxmode=0666,newinstance', 'devpts', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'bind', '/tmp/mock-selinux-plugin.id6ehnoj', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-t', 'tmpfs', '-o', 'private,mode=0755', 'tmpfs', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'rbind', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/mount', '-n', '-o', 'remount,private,rbind', '--target', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG file_util.py:18:  ensuring that dir exists: /var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir
+DEBUG package_manager.py:295:  ['/usr/bin/dnf5', 'builddep', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.buildreqs.nosrc.rpm', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing']
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:551:  Using nspawn with args ['--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf']
+DEBUG util.py:556:  Executing command: ['/usr/bin/systemd-nspawn', '-q', '-M', 'f6bb9e41b8cc40ec825e737865ea676f', '-D', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root', '-a', '--capability=cap_ipc_lock', '--bind=/tmp/mock-resolv._8hjm0sx:/etc/resolv.conf', '--console=pipe', '--setenv=TERM=vt100', '--setenv=SHELL=/bin/bash', '--setenv=HOME=/var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir', '--setenv=HOSTNAME=mock', '--setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin', '--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"', '--setenv=PS1=<mock-chroot> \\s-\\v\\$ ', '--setenv=LANG=C.UTF-8', '--setenv=LC_MESSAGES=C.UTF-8', '--resolv-conf=off', '/usr/bin/dnf5', 'builddep', '--installroot', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/builddir/build/SRPMS/python-boto3-1.37.14-1.eln147.buildreqs.nosrc.rpm', '--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing', '--setopt=tsflags=nocontexts'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/installation-homedir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8', 'LC_MESSAGES': 'C.UTF-8', 'SYSTEMD_NSPAWN_TMPFS_TMP': '0', 'SYSTEMD_SECCOMP': '0'} and shell False
+DEBUG util.py:459:  Updating and loading repositories:
+DEBUG util.py:459:  Repositories loaded.
+DEBUG util.py:459:  Failed to resolve the transaction:
+DEBUG util.py:459:  Package "util-linux-core-2.40.4-7.eln146.aarch64" is already installed.
+DEBUG util.py:459:  Package "pyproject-rpm-macros-1.17.0-1.eln146.noarch" is already installed.
+DEBUG util.py:459:  Package "python3-devel-3.13.2-2.eln146.aarch64" is already installed.
+DEBUG util.py:459:  Package "python3-packaging-24.2-3.eln145.noarch" is already installed.
+DEBUG util.py:459:  Package "python3-pip-24.3.1-2.eln145.noarch" is already installed.
+DEBUG util.py:459:  Package "python3-pytest-8.3.5-2.eln146.noarch" is already installed.
+DEBUG util.py:459:  Package "python3-pytest-xdist-3.6.1-5.eln145.noarch" is already installed.
+DEBUG util.py:459:  Package "python3-setuptools-74.1.3-5.eln145.noarch" is already installed.
+DEBUG util.py:459:  Problem: nothing provides requested (python3dist(botocore) < 1.38~~ with python3dist(botocore) >= 1.37.14)
+DEBUG util.py:608:  Child return code was: 1
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root/var/lib/mock/eln-build-side-108102-58033177-6561774/root'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys/fs/selinux'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc/filesystems'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/pts'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/dev/shm'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/sys'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:634:  child environment: None
+DEBUG util.py:556:  Executing command: ['/bin/umount', '-n', '-l', '/var/lib/mock/eln-build-side-108102-58033177-6561774/root/proc'] with env {'TERM': 'vt100', 'SHELL': '/bin/sh', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'LANG': 'C.UTF-8'} and shell False
+DEBUG util.py:608:  Child return code was: 0
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774/root
+DEBUG util.py:183:  kill orphans in chroot /var/lib/mock/eln-build-side-108102-58033177-6561774-bootstrap/root


### PR DESCRIPTION
Sometimes, RPM builds fail because of dependency issues. These failures are generally reported in root.log and are not visible in build.log.