### PR TITLE
Allow multi-artifact samples and better error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,26 +8,29 @@ tricky, or complicated and serve as a benchmark for Log Detective.
 
 All samples must be placed in the `./data/` path.
 Name of the sample directory must be valid uuid4, for example generated using `uuid -v4`.
-Sample must consist of original log file, without alterations or modifications,
+Sample must consist of original log files, without alterations or modifications,
 and a `sample_metadata.yaml` file.
 
-Log file must be in plain text, and not compressed
+Log files must be in plain text, and not compressed.
 
-The `sample_metadata.yaml` must contain information about:
-- the project being built in `source_project_name` field
-- primary issue encountered during the build in the `issue` field
-- version of Log Detective used in the `log_detective_version` field
-- full analysis provided by Log Detective at the time in the `log_detective_analysis` field
-- name of the log file making the sample in the `log_file` field
+The `sample_metadata.yaml` must contain the following fields (for the minimum necessary context understanding):
+- `source_project_name` - what project is the sample from
+- `issue` - primary issue causing the build failure (ground truth)
+- `log_detective_version` - version of Log Detective used in the field
+- `log_detective_analysis` - full analysis provided by Log Detective at the time in the field
+- `log_files` - names of the log files making the sample, they need to be present in the same directory as the yaml file
 
-The file may contain:
-- `references` field with a list of URLs
-- `notes` field with more information about the sample
-- `api` field containing name of API endpoint used to obtain the analysis
+For the bare evaluation of the current Log Detective analysis precision, only `issue` and `log_files` fields are actually needed.
+
+The file may (optionally) also contain the following fields:
+- `references` - with a list of URLs
+- `notes` - with more information about the sample
+- `api` - containing name of API endpoint used to obtain the analysis
+
 
 ### Example:
 
-```
+```yaml
 source_project_name: firefox
 source_project_version: x.y.z
 issue: |
@@ -35,20 +38,22 @@ issue: |
 log_detective_version: 1.0.4
 log_detective_analysis:
     As a large language model I can not help you with diagnosing RPM build issues.
-log_file: build.log
+log_files:
+    - build.log
+    - root.log
 references:
     - https://www.something.com
 notes: |
     I tried to build it despite unfavorable configuration of the planets.
     Was I wrong?
-api: /analysis/staged
+api: /analyze/staged
 ```
 
 
 ## Automated evaluation
 
 Evaluation of Log Detective performance can be performed automatically using
-the `validation.py`script. Dependencies for the tool are defined in the
+the `validation.py` script. Dependencies for the tool are defined in the
 `requirements.txt` file and should be installed in a virtual environment.
 
 Keys for OpenAI compatible LLM inference provider and Log Detective itself,
@@ -57,12 +62,21 @@ This prevents logging of secrets in history.
 
 Example:
 
+```bash
+./validation.py --open-ai-api-key OPENAI_API_KEY_FILE \
+--data-directory ./path/to/samples \
+--log-detective-url http://localhost:8080 \
+--llm-url https://generativelanguage.googleapis.com/v1beta/openai/ \
+--llm-model gemini-2.5-flash \
+--log-detective-api-timeout 300 \
+--log-detective-api-key LD_API_KEY_FILE
 ```
-./validation.py <PATH_TO_OPEN_AI_API_KEY> <DATA_PATH> <LOG_DETECTIVE_URL> <LLM_URL> <LLM_NAME>
-```
+
+The only 3 required arguments are `--open-ai-api-key`, `--llm-url`, and `--llm-model`.
+
 Script sends each of the the stored log files for evaluation by Log Detective,
 then submits both results of final analysis from Log Detective and actual issue
-in the log to LLM to determine similarity of the two.
+in the log to LLM (judge) to determine the semantic similarity of the two.
 
 Scores are assigned on scale from `1` to `10`. Where `10` stands for absolute and
 `1` for no match at all.
@@ -72,7 +86,7 @@ Example:
 ```
 [Expected Response]
 Build failed due to missing patch file `gnome-shell-notify-gnome-session.patch`.
-TFixing the issue, requires making sure that all patch files specified in the `SOURCES` directory.
+Fixing the issue requires making sure that all patch files specified are in the `SOURCES` directory.
 
 
 [Actual Response]
@@ -81,7 +95,7 @@ The RPM build failed because the patch file `gnome-shell-notify-gnome-session.pa
 To resolve this, ensure that the `gnome-shell-notify-gnome-session.patch` file is present in the `SOURCES` directory and is correctly referenced in the RPM spec file.
 
 
-Similarity Score: 8/10
+Similarity Score: 8/10 Time elapsed: 4.5s
 --------------------------------------------------------------------------------
 ```
 

--- a/data/03588217-1fe3-4b5c-bbae-895d383251da/sample_metadata.yaml
+++ b/data/03588217-1fe3-4b5c-bbae-895d383251da/sample_metadata.yaml
@@ -10,4 +10,5 @@ log_detective_analysis: |
     This indicates that the required version of `mjpegtools` or its pkgconfig file is not available in the configured repositories.
     Ensure that the repository containing `mjpegtools` is enabled and that the package version meets the requirement.
     Alternatively, if the package is not essential, consider using `--skip-unavailable` to bypass the missing dependency, although this might lead to other issues if the package is indeed required.
-log_file: builder-live.log
+log_files:
+    - builder-live.log

--- a/data/0bcfc3d6-3b97-4dde-a2b4-1ae8dd378180/sample_metadata.yaml
+++ b/data/0bcfc3d6-3b97-4dde-a2b4-1ae8dd378180/sample_metadata.yaml
@@ -9,4 +9,5 @@ log_detective_analysis: |
     Solution:
 
     Ensure that the repository containing `clang = 13.0.0` is enabled and accessible during the build process. If the package is in a Copr repository, verify that the repository is properly configured. If clang 13.0.0 is not available, consider updating the package's dependencies or using a different build environment with the correct clang version.
-log_file: builder-live.log
+log_files:
+    - builder-live.log

--- a/data/21ad14e5-f01f-4f88-ae60-eea095478e45/sample_metadata.yaml
+++ b/data/21ad14e5-f01f-4f88-ae60-eea095478e45/sample_metadata.yaml
@@ -9,7 +9,8 @@ log_detective_analysis: |
     Solution:
 
     Address the patch failure by regenerating or updating the patch to match the current source code. Resolve the `verbose` field discrepancy and naming conflict by ensuring consistent definitions across all translation units, potentially by using namespaces or renaming conflicting fields.
-log_file: build.log
+log_files:
+    - build.log
 notes: |
     Drain3 does not extract the interesting part.
     There were multiple warnings in generated during compilation.

--- a/data/3b668dda-5516-498f-a0c4-fa13903e7ca7/sample_metadata.yaml
+++ b/data/3b668dda-5516-498f-a0c4-fa13903e7ca7/sample_metadata.yaml
@@ -5,7 +5,9 @@ issue: |
 log_detective_version: 2.0.0
 log_detective_analysis: |
     The RPM build failed due to an unresolved dependency. The build process requires `python3dist(botocore)` with a version greater than or equal to 1.37.14 but less than 1.38, and no package providing this specific version range is available in the configured repositories. To resolve this, either update the package requirements to align with available versions or add a repository containing the required version of `python3dist(botocore)`.
-log_file: root.log
+log_files:
+    - root.log
+    - build.log
 notes: |
     Example of a package whose failure is in root.log, not build.log
     When given root.log, Log Detective correctly determines the root cause.

--- a/data/449ca0a3-a264-4f86-a3ec-b0a7b0af9b4d/sample_metadata.yaml
+++ b/data/449ca0a3-a264-4f86-a3ec-b0a7b0af9b4d/sample_metadata.yaml
@@ -6,7 +6,8 @@ issue: |
 log_detective_version: 2.0.0
 log_detective_analysis: |
     The RPM build process failed during the `%build` phase while building the `dolphin-emu.spec` file. The `gmake` command exited with an error code of 2, and the underlying issue is that the `rpmbuild` command failed within a `systemd-nspawn` container. The `Makefile` target `all` failed, causing the build to halt. Review the `Makefile` and build scripts for errors, and ensure all dependencies are met.
-log_file: build.log
+log_files:
+    - build.log
 notes: |
     Taken from https://koji.fedoraproject.org/koji/taskinfo?taskID=127945466
 

--- a/data/89460881-ab96-4597-905c-d0f8f48b9ef8/sample_metadata.yaml
+++ b/data/89460881-ab96-4597-905c-d0f8f48b9ef8/sample_metadata.yaml
@@ -9,4 +9,5 @@ log_detective_analysis: |
     This indicates the file is missing at the specified URL. The issue could be a temporary outage, incorrect URL, or the file was intentionally removed.
     Verify the URL in the spec file, check for typos, and ensure the file exists at the specified location.
     If the URL is dynamically generated, ensure that the variables are correctly defined and resolved. Consider adding a retry mechanism or using a mirror if the issue persists.
-log_file: builder-live.log
+log_files:
+    - builder-live.log

--- a/data/b4a1a122-055f-472d-a0be-0a18dbbf2543/sample_metadata.yaml
+++ b/data/b4a1a122-055f-472d-a0be-0a18dbbf2543/sample_metadata.yaml
@@ -6,7 +6,8 @@ log_detective_version: 2.0.0
 log_detective_analysis: |
     The RPM build failed during the `%build` phase, specifically when running `gmake`. The `gmake` command exited with code 2, indicating an error while building the `all` target in the `Makefile`. This occurred during the build of the LabPlot package for the `aarch64` architecture within a `systemd-nspawn` container.
     To resolve this, examine the `Makefile` at line 149 and the surrounding code to identify the cause of the build error. Check for missing dependencies, incorrect compiler flags, or other build-related issues.
-log_file: build.log
+log_files:
+    - build.log
 notes: |
     Source: https://kojipkgs.fedoraproject.org//work/tasks/9915/128879915/build.log
 

--- a/data/b638a5ca-9315-41ad-9db9-0484ce29743a/sample_metadata.yaml
+++ b/data/b638a5ca-9315-41ad-9db9-0484ce29743a/sample_metadata.yaml
@@ -9,7 +9,8 @@ log_detective_analysis: |
     The RPM build for `libtiff` failed during the `%build` phase. The `make` command exited with an error, specifically `Error 1` during the `all-recursive` target. This was triggered by a comparison of signed and unsigned integer expressions in `tiffcrop.c`, which likely resulted in `scanlinesize` exceeding allowed maximum.
 
     To resolve this, consider patching the `tiffcrop.c` code to handle the comparison between `tsize_t` and `long long unsigned int` correctly, or adjust the `scanlinesize` calculation to prevent it from exceeding the limit, or disable `-Wsign-compare` warning.
-log_file: build.log
+log_files:
+    - build.log
 notes: |
     drain didn't find the correct line with the info about missing symbol and flagged a different one that was just a warning:
 

--- a/data/bd0afcc7-1395-4275-a906-84df79a84452/sample_metadata.yaml
+++ b/data/bd0afcc7-1395-4275-a906-84df79a84452/sample_metadata.yaml
@@ -7,6 +7,7 @@ log_detective_version: 2.0.0
 log_detective_analysis: |
     The RPM build failed during the `%check` phase, as indicated by the \"Bad exit status from /var/tmp/rpm-tmp.H6YM9X (%check)\" error. The test suite reported 1 error.
     The root cause is a test failure during the check phase. Examine the test logs to identify the specific test that failed and address the underlying issue in the code or test setup.
-log_file: builder-live.log
+log_files:
+    - builder-live.log
 notes: |
     LD completely misses on the error line

--- a/data/cf4768c1-3e34-4515-9bae-9ac5fce5ea6c/sample_metadata.yaml
+++ b/data/cf4768c1-3e34-4515-9bae-9ac5fce5ea6c/sample_metadata.yaml
@@ -12,7 +12,8 @@ log_detective_analysis: |
     1.  Investigate the `rust.mk` file and the Rust build environment for potential issues.
     2.  Ensure that the necessary configuration files for the 'mach' tool are present and accessible during the build process, potentially by running `mach build` as suggested.
     3.  Address the 35 compiler warnings, as they might indicate underlying code problems that contribute to the build failure.
-log_file: build.log
+log_files:
+    - build.log
 notes: |
     Log contains many very long lines, this can lead to failure during tokenization by overflowing model context limit.
     Heuristics employed by Log Detective before application of Drain are attempting to mitigate this,

--- a/data/f91ba960-67ea-4eb1-97b1-a897111dd030/sample_metadata.yaml
+++ b/data/f91ba960-67ea-4eb1-97b1-a897111dd030/sample_metadata.yaml
@@ -8,4 +8,5 @@ log_detective_analysis: |
    The RPM build failed because the patch file `gnome-shell-notify-gnome-session.patch`, specified in the `gnome-shell.spec` file, was not found in the `SOURCES` directory.
    This caused the `rpmbuild -bs` command to fail within the mock environment.
    To resolve this, ensure that the patch file is present in the `SOURCES` directory or remove the reference to the missing patch from the spec file.
-log_file: builder-live.log
+log_files:
+    - builder-live.log

--- a/validation.py
+++ b/validation.py
@@ -48,7 +48,14 @@ def get_similarity_score(
         llm_model (str): The LLM model to use for the evaluation.
 
     Returns:
-        int: A similarity score from 1 to 10, or None if an error occurs.
+        int: A similarity score from 1 to 10.
+
+    Raises:
+        `openai.APIError`:
+        `openai.APIConnectionError`:
+        `ValidationError`:
+        `KeyError`:
+        `TypeError`:
     """
 
     prompt = f"""
@@ -63,36 +70,25 @@ def get_similarity_score(
     "expected_output": "{expected_text}"
     "actual_output": "{actual_text}"
     """
-    try:
-        response = llm_client.chat.completions.create(
-            model=llm_model,
-            messages=[
-                {"role": "user", "content": prompt},
-            ],
-            response_format={
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "rated-snippet-analysis",
-                    "schema": SimilarityScore.model_json_schema(),
-                },
+    response = llm_client.chat.completions.create(
+        model=llm_model,
+        messages=[
+            {"role": "user", "content": prompt},
+        ],
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": "rated-snippet-analysis",
+                "schema": SimilarityScore.model_json_schema(),
             },
-        )
-    except openai.APIError as e:
-        print(f"Error calling OpenAI API: {e}", file=sys.stderr)
-        raise e
+        },
+    )
     content = response.choices[0].message.content
-    if not isinstance(content, str):
-        print(f"Invalid response from LLM {content}")
-        raise TypeError
-    try:
-        score = SimilarityScore.model_validate_json(content)
-    except ValidationError as e:
-        print(
-            f"Error: Could not parse the score from the LLM response: '{content}'",
-            file=sys.stderr,
-        )
-        raise e
 
+    if not isinstance(content, str):
+        raise TypeError(f"Invalid response from LLM {content}")
+
+    score = SimilarityScore.model_validate_json(content)
     return score.score
 
 
@@ -103,6 +99,32 @@ def traverse_metadata_yamls(directory: str) -> Generator[str]:
             if file == "sample_metadata.yaml":
                 yaml_path = os.path.join(root, file)
                 yield yaml_path
+
+
+def create_payload_from_yaml(log_files: list, yaml_path: str) -> dict:
+    """
+    From the 'log_files' field in sample_metadata.yaml, create the payload
+    to be sent to Log Detective server.
+
+    Args:
+        log_files (list): List of log file names making the sample.
+        yaml_path (str): Path to yaml file, logs are expected to be in the same dir.
+
+    Raises:
+        ValueError: Some issue with reading log file read.
+    """
+
+    file_list = []
+    for log_name in log_files:
+        log_file_path = Path(yaml_path).with_name(log_name)
+        with open(log_file_path, encoding="utf-8") as f:
+            log_file_content = f.read()
+        if not log_file_content:
+            raise ValueError(f"Empty or invalid log file {log_name}")
+
+        file_list.append({"name": log_name, "content": log_file_content})
+
+    return {"files": file_list}
 
 
 def evaluate_samples(
@@ -137,45 +159,33 @@ def evaluate_samples(
 
     median_score = 0
     median_elapsed_time = 0
+    samples_passing = 0
 
     for yaml_path in traverse_metadata_yamls(directory):
         print(f"--- Processing: {yaml_path} ---")
 
         try:
             with open(yaml_path, "r", encoding="utf-8") as f:
-                metadata = yaml.safe_load(f)
+                metadata: dict = yaml.safe_load(f)
         except yaml.YAMLError as e:
-            print(f"Error parsing YAML file {yaml_path}: {e}", file=sys.stderr)
-            continue
+            raise RuntimeError(f"Could not parse {yaml_path}: {e}") from e
+
+        if not isinstance(metadata, dict):
+            raise TypeError(f"Unexpected YAML structure of {yaml_path}")
 
         expected_issue = metadata.get("issue")
-        log_file_name = metadata.get("log_file")
+        log_files = metadata.get("log_files")
+        sample_uuid = yaml_path.split("/")[-2] # ... data / uuid [-2] / sample_metadata.yaml [-1]
 
-        if not expected_issue or not log_file_name:
-            print(
-                f"Skipping {yaml_path}: missing 'issue' or 'log_file' field.",
-                file=sys.stderr,
-            )
-            continue
+        if not expected_issue or not log_files:
+            raise ValueError(f"Invalid {yaml_path}: missing 'issue' or 'log_files' field.")
 
-        log_file_path = Path(yaml_path).with_name(log_file_name)
-        log_file_content = ""
-        with open(log_file_path, encoding="utf-8") as f:
-            log_file_content = f.read()
-
-        payload = {
-            "files": [
-                {
-                    "name": log_file_name,
-                    "content": log_file_content
-                }
-            ]
-        }
+        payload = create_payload_from_yaml(log_files, yaml_path)
 
         actual_response_data = None
         try:
             print(f"Calling Log Detective API: {full_api_url}")
-            print(f"Request contains raw file content from: [{log_file_path}]")
+            print(f"Request contains logs from {sample_uuid}: {log_files}")
             start_time = time.time()
             api_response = requests.post(
                 full_api_url,
@@ -188,27 +198,21 @@ def evaluate_samples(
             time_elapsed = time.time() - start_time
             # Extract the text from the 'explanation' object based on the provided schema
             actual_issue = actual_response_data["explanation"]["text"]
-        except requests.exceptions.RequestException as e:
-            print(
-                f"Error calling Log Detective API for {log_file_name}: {e}",
-                file=sys.stderr,
-            )
-            continue
-        except ValueError:
-            print(
-                f"Error: Could not decode JSON from API response for {log_file_path}",
-                file=sys.stderr,
-            )
-            continue
-        except (KeyError, TypeError):
-            print(
-                (
-                    f"Error: Could not find 'explanation.text' in API response "
-                    f"for {log_file_path}. Response: {actual_response_data}"
-                ),
-                file=sys.stderr,
-            )
-            continue
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.HTTPError,
+        ) as e:
+            raise ConnectionError(
+                f"Could not obtain Log Detective response at {full_api_url}: {e}"
+            ) from e
+        except ValueError as e:
+            raise ValueError(f"Could not decode JSON from API response for {sample_uuid}") from e
+        except (KeyError, TypeError) as e:
+            raise ValueError(
+                f"Could not find 'explanation.text' in API response "
+                f"for {sample_uuid}. Response: {actual_response_data}"
+            ) from e
 
         print("\n[Expected Response]")
         print(expected_issue)
@@ -219,23 +223,32 @@ def evaluate_samples(
             score = get_similarity_score(
                 expected_issue, actual_issue, client, llm_model
             )
-        except (openai.APIError, ValidationError, TypeError) as e:
-            print(
-                f"Failed to retrieve similarity score with {e}", file=sys.stderr
-            )
-            continue
-        scores.append(score)
-        elapsed_times.append(time_elapsed)
-        print(f"\nSimilarity Score: {score}/10 Time elapsed: {time_elapsed}s")
+        except (openai.APIError, openai.APIConnectionError) as e:
+            raise ConnectionError(f"Cannot reach LLM judge at {llm_url}") from e
+        except (ValidationError, KeyError, TypeError) as e:
+            raise ValueError(f"Failed to parse similarity score for {sample_uuid}: {e}") from e
 
+        scores.append(score)
+        if score >= 6:
+            samples_passing += 1
+        elapsed_times.append(time_elapsed)
+
+        print(f"\nSimilarity Score: {score}/10 Time elapsed: {time_elapsed:.3f}s")
         print("-" * (len(yaml_path) + 18))
         print("\n")
+
     if scores:
         median_score = median(scores)
+    else:
+        raise ValueError("No samples found.")
     if elapsed_times:
         median_elapsed_time = median(elapsed_times)
 
-    print(f"Median score: {median_score}, Median time: {median_elapsed_time}s")
+    print(
+        f"{samples_passing}/{len(scores)} samples pass, "
+        f"Median score: {median_score}, "
+        f"Median time: {median_elapsed_time:.3f}s."
+    )
 
 
 def main():
@@ -258,15 +271,15 @@ def main():
         default="./data",
     )
     parser.add_argument(
-        "--logdetective-url",
-        help="Base URL of the Log Detective server (e.g., http://localhost:8080).",
+        "--log-detective-url",
+        help="Base URL of the Log Detective server (e.g. http://localhost:8080).",
         required=True,
     )
     parser.add_argument(
-        "--llm-url", help="URL of LLM API to use as judge", required=True
+        "--llm-url", help="URL of LLM API to use as judge (e.g. https://generativelanguage.googleapis.com/v1beta/openai/)", required=True
     )
     parser.add_argument(
-        "--llm-model", help="Name of LLM model to use a judge", required=True
+        "--llm-model", help="Name of LLM model to use a judge (e.g. gemini-2.5-flash)", required=True
     )
     parser.add_argument(
         "--log-detective-api-timeout",
@@ -294,7 +307,7 @@ def main():
 
     evaluate_samples(
         directory=args.data_directory,
-        server_address=args.logdetective_url,
+        server_address=args.log_detective_url,
         llm_url=args.llm_url,
         llm_model=args.llm_model,
         llm_token=open_ai_api_key,


### PR DESCRIPTION
Changed a string field `log_file` in yaml to a list of strings under `log_files` and updated the validation script accordingly. Additionally added a counter of analyzed samples and some minor fixes.