### PR TITLE
Improve and stabilize the LLM judge prompt

### DIFF
--- a/data/03588217-1fe3-4b5c-bbae-895d383251da/sample_metadata.yaml
+++ b/data/03588217-1fe3-4b5c-bbae-895d383251da/sample_metadata.yaml
@@ -1,9 +1,9 @@
 source_project_name: gstreamer1-plugins-bad-free
 source_project_version: 1.26.5-3
 issue: |
-   RPM build failed due to missing dependency  `pkgconfig(mjpegtools) >= 2.0.0`.
-   In order to resolve the issue, make sure that all dependencies required by the package
-   are available in installed repositories.
+    RPM build failed due to missing dependency  `pkgconfig(mjpegtools) >= 2.0.0`.
+    In order to resolve the issue, make sure that all dependencies required by the package
+    are available in installed repositories.
 log_detective_version: 2.0.0
 log_detective_analysis: |
     The build failed because a dependency, `pkgconfig(mjpegtools) >= 2.0.0`, could not be resolved during the `dnf5 builddep` stage within the mock environment.

--- a/data/b4a1a122-055f-472d-a0be-0a18dbbf2543/sample_metadata.yaml
+++ b/data/b4a1a122-055f-472d-a0be-0a18dbbf2543/sample_metadata.yaml
@@ -13,11 +13,11 @@ notes: |
 
     The error is hidden inside the file and not at the end. The error:
     ```
-    /builddir/build/BUILD/LabPlot-2.11.80_20241117.082905.4e770ae-build/labplot-4e770ae2d988362dca637aef2b74610a4a1456c2/src/backend/datasources/filters/XLSXFilter.cpp: In member function ‘QXlsx::Cell::CellType XLSXFilterPrivate::columnTypeInRange(int, const QXlsx::CellRange&) const’:
-    /builddir/build/BUILD/LabPlot-2.11.80_20241117.082905.4e770ae-build/labplot-4e770ae2d988362dca637aef2b74610a4a1456c2/src/backend/datasources/filters/XLSXFilter.cpp:795:62: error: unable to deduce ‘const auto*’ from ‘QXlsx::Document::cellAt(int, int) const(row, ((int)column))’
+    /builddir/build/BUILD/LabPlot-2.11.80_20241117.082905.4e770ae-build/labplot-4e770ae2d988362dca637aef2b74610a4a1456c2/src/backend/datasources/filters/XLSXFilter.cpp: In member function 'QXlsx::Cell::CellType XLSXFilterPrivate::columnTypeInRange(int, const QXlsx::CellRange&) const':
+    /builddir/build/BUILD/LabPlot-2.11.80_20241117.082905.4e770ae-build/labplot-4e770ae2d988362dca637aef2b74610a4a1456c2/src/backend/datasources/filters/XLSXFilter.cpp:795:62: error: unable to deduce 'const auto*' from 'QXlsx::Document::cellAt(int, int) const(row, ((int)column))'
     795 |                         const auto* cell = m_document->cellAt(row, column);
         |                                            ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
-    /builddir/build/BUILD/LabPlot-2.11.80_20241117.082905.4e770ae-build/labplot-4e770ae2d988362dca637aef2b74610a4a1456c2/src/backend/datasources/filters/XLSXFilter.cpp:795:74: note:   mismatched types ‘const auto*’ and ‘std::shared_ptr<QXlsx::Cell>’
+    /builddir/build/BUILD/LabPlot-2.11.80_20241117.082905.4e770ae-build/labplot-4e770ae2d988362dca637aef2b74610a4a1456c2/src/backend/datasources/filters/XLSXFilter.cpp:795:74: note:   mismatched types 'const auto*' and 'std::shared_ptr<QXlsx::Cell>'
     795 |                         const auto* cell = m_document->cellAt(row, column);
         |                                                                          ^
     ```

--- a/data/e583fa55-21a3-47c2-9ab3-3dbe9a026669/sample_metadata.yaml
+++ b/data/e583fa55-21a3-47c2-9ab3-3dbe9a026669/sample_metadata.yaml
@@ -1,6 +1,5 @@
 source_project_name: cri-o
-source_project_version: |-
-    1.33.0-2.20250509075346213411.pr9190.239.geb76e5c22
+source_project_version: 1.33.0-2.20250509075346213411.pr9190.239.geb76e5c22
 issue: |
     The build seems to be running without issues, the dependencies install fine.
 log_detective_version: 3.10.0

--- a/data/f1a74151-d8a9-4a7c-9f54-f4e28a659f0c/sample_metadata.yaml
+++ b/data/f1a74151-d8a9-4a7c-9f54-f4e28a659f0c/sample_metadata.yaml
@@ -1,5 +1,5 @@
 source_project_name: dnf
-source_project_version: ''
+source_project_version: 4.19.0-1
 issue: |
     Both the dnf package from the Fedora base image and the dnf5 package from the dnf5-testing Copr repo provide the /etc/dnf/dnf.conf file.
     This occurs because when using the dnf5-testing Copr repository, all dnf related packages are intended to come from this repository, set up with the obsoletion macro to manage the transition from dnf to dnf5.

--- a/scripts/create_samples.py
+++ b/scripts/create_samples.py
@@ -49,7 +49,8 @@ def _str_presenter(dumper, data: str):
             line = line.replace(old, new)
         cleaned.append(line)
     data = "\n".join(cleaned)
-    if len(data) > 50:
+    if len(data) > 50 and len(data.split()) > 1:
+        data = data.rstrip() + "\n"
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
     data = data.replace("\n", " ").strip()
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)

--- a/scripts/create_samples.py
+++ b/scripts/create_samples.py
@@ -120,7 +120,7 @@ def get_logdetective_analysis(json_dict: dict) -> str:
     }
 
     api_response = requests.post(
-        f"{LOGDETECTIVE_URL}/analyze/staged",
+        f"{LOGDETECTIVE_URL}/analyze",
         json=payload,
         timeout=60,
     )

--- a/validation.py
+++ b/validation.py
@@ -204,7 +204,7 @@ def evaluate_samples(
             requests.exceptions.HTTPError,
         ) as e:
             raise ConnectionError(
-                f"Could not obtain Log Detective response at {full_api_url}: {e}"
+                f"Could not obtain Log Detective response for sample {sample_uuid}: {e}"
             ) from e
         except ValueError as e:
             raise ValueError(f"Could not decode JSON from API response for {sample_uuid}") from e

--- a/validation.py
+++ b/validation.py
@@ -143,7 +143,7 @@ def evaluate_samples(
         directory (str): The path to the directory containing the samples.
         server_address (str): The base address of the server.
     """
-    api_endpoint = "/analyze/staged"
+    api_endpoint = "/analyze"
 
     full_api_url = f"{server_address}{api_endpoint}"
 

--- a/validation.py
+++ b/validation.py
@@ -36,6 +36,22 @@ class SimilarityScore(BaseModel):
     )
 
 
+JUDGE_SYSTEM_PROMPT = """\
+Rate how well the 'actual_output' addresses the issue described in 'expected_output'.
+The comparison is one-directional: does the actual output identify the same root cause?
+Ask: "Could a maintainer fix the issue just as well following the actual output as the expected output?"
+
+Score on an integer scale from 1 to 10:
+- 1: Completely wrong topic or root cause.
+- 3-5: Same general area, but missing (or not fully addressing) the core issue.
+- 6: Identifies the correct root cause, but lacks enough detail to act on it. The explanation would be enough for an experienced packager, an inexperienced will probably lack information to efficiently fix the issue.
+- 7-9: Correctly identifies the root cause; more detail or different terminology is fine.
+- 10: Fully and precisely addresses everything in the expected output.
+
+Do not penalize for: different terminology, higher level of technical detail, different lengths.
+"""
+
+
 def get_similarity_score(
     expected_text: str, actual_text: str, llm_client: openai.OpenAI, llm_model: str
 ) -> int:
@@ -58,28 +74,20 @@ def get_similarity_score(
         `TypeError`:
     """
 
-    prompt = f"""
-    Rate how well the 'actual_output' addresses the issue described in 'expected_output'.
-    The comparison is one-directional: does the actual output identify the same root cause?
-    Ask: "Could a maintainer fix the issue just as well following the actual output as the expected output?"
-
-    Score on an integer scale from 1 to 10:
-    - 1: Completely wrong topic or root cause.
-    - 3-5: Same general area, but missing (or not fully addressing) the core issue.
-    - 6: Identifies the correct root cause, but lacks enough detail to act on it. The explanation would be enough for an experienced packager, an inexperienced will probably lack information to efficiently fix the issue.
-    - 7-9: Correctly identifies the root cause; more detail or different terminology is fine.
-    - 10: Fully and precisely addresses everything in the expected output.
-
-    Do not penalize for: different terminology, higher level of technical detail, different lengths.
-
-    ---
-    "expected_output": "{expected_text}"
-    "actual_output": "{actual_text}"
-    """
+    judge_user_prompt = "\n".join(
+        [
+            "expected_output:",
+            expected_text,
+            "",
+            "actual_output:",
+            actual_text,
+        ]
+    )
     response = llm_client.chat.completions.create(
         model=llm_model,
         messages=[
-            {"role": "user", "content": prompt},
+            {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
+            {"role": "user", "content": judge_user_prompt},
         ],
         response_format={
             "type": "json_schema",

--- a/validation.py
+++ b/validation.py
@@ -59,12 +59,18 @@ def get_similarity_score(
     """
 
     prompt = f"""
-    Analyze the semantic similarity between the 'expected_output' and the 'actual_output'.
+    Rate how well the 'actual_output' addresses the issue described in 'expected_output'.
+    The comparison is one-directional: does the actual output identify the same root cause?
+    Ask: "Could a maintainer fix the issue just as well following the actual output as the expected output?"
 
-    Your task is to rate their similarity on an integer scale from 1 to 10.
-    - A score of 1 means they are completely dissimilar in meaning, topic, and intent.
-    - **A score of 7-9 means the actual output contains all the critical information of the expected output, but also includes additional, relevant explanations or details.**
-    - A score of 10 means they are semantically identical, conveying the exact same information and intent, even if phrasing differs.
+    Score on an integer scale from 1 to 10:
+    - 1: Completely wrong topic or root cause.
+    - 3-5: Same general area, but missing (or not fully addressing) the core issue.
+    - 6: Identifies the correct root cause, but lacks enough detail to act on it. The explanation would be enough for an experienced packager, an inexperienced will probably lack information to efficiently fix the issue.
+    - 7-9: Correctly identifies the root cause; more detail or different terminology is fine.
+    - 10: Fully and precisely addresses everything in the expected output.
+
+    Do not penalize for: different terminology, higher level of technical detail, different lengths.
 
     ---
     "expected_output": "{expected_text}"


### PR DESCRIPTION
The analyses in [] were done using the new judge prompt on *separate* Log Detective analysis runs. After the improved prompt, the following 7/27 samples are consistently evaluated as not passing:

`sample` [three judge runs] => details:
[`449ca0a3`](https://github.com/fedora-copr/logdetective-sample/blob/main/data/449ca0a3-a264-4f86-a3ec-b0a7b0af9b4d/sample_metadata.yaml) [4,6,4] => issue contains module name where the warnings/errors were found, analysis only mentions function names (too specific)
[`b4a1a122`](https://github.com/fedora-copr/logdetective-sample/blob/main/data/b4a1a122-055f-472d-a0be-0a18dbbf2543/sample_metadata.yaml) [4,4,4] => issue contains details, analysis only says a compilation error, older versions seemed to get it right
[`b77aaa0f`](https://github.com/fedora-copr/logdetective-sample/blob/main/data/b77aaa0f-0a41-42cc-8e75-73881a210cc0/sample_metadata.yaml) [4,4,4] => too general description by LD, in 3.10 it sometimes included the note about different interpretations of function declarations, v4 doesn't know how to include it
[`bd0afcc7`](https://github.com/fedora-copr/logdetective-sample/blob/main/data/bd0afcc7-1395-4275-a906-84df79a84452/sample_metadata.yaml) [4,6,4] => LD is too broad, also analyses are very similar, so I don't get the 4-6 randomness
[`c0f85594`](https://github.com/fedora-copr/logdetective-sample/blob/main/data/c0f85594-2b4e-4632-9d07-b433ceeafe62/sample_metadata.yaml) [1,1,1] => rust error (probably not caught by drain, could be caught by csgrep), also the log is pretty big
[`cf4768c1`](https://github.com/fedora-copr/logdetective-sample/blob/main/data/cf4768c1-3e34-4515-9bae-9ac5fce5ea6c/sample_metadata.yaml) [4,4,4] => rust compilation errors (probably couldn't be extracted, prefixed by timestamps and also a weird format for compilation errors)
[`d64785f0`](https://github.com/fedora-copr/logdetective-sample/blob/main/data/d64785f0-6642-4aad-b3fb-4b3dbd0a3511/sample_metadata.yaml) [1,1,4] => root cause is found in mock_output.log, but not detected by LD, also the explanations are very similar so the 1-1-4 is weird too

Some of these "failing" samples could be fixed by telling Log Detective to include a precise code locations of the compilation/linker errors.

Otherwise, the judge produces more consistent results (samples that used to fluctuate around 5-9 are now 9s or 10s consistently).
